### PR TITLE
Should this be a config, not a plugin?

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-# Cypress ESLint Plugin
+# Cypress ESLint Config
 
-An ESLint plugin for projects that use Cypress.
+An ESLint config for projects that use Cypress.
 
 Specifies the environment and globals (`cy`, `Cypress`, etc) for use when writing tests using [Cypress](https://cypress.io).
 
 ## Installation
 
 ```sh
-npm install eslint-plugin-cypress --save-dev
+npm install eslint-config-cypress --save-dev
 ```
 
 ## Usage
 
-Add `cypress` as a plugin in your `.eslintrc`:
+Add `cypress` as a config in your `.eslintrc`:
 
 ```json
 {
-  "plugins": [
+  "extends": [
     "cypress"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,23 +1,23 @@
 {
-  "name": "eslint-plugin-cypress",
+  "name": "eslint-config-cypress",
   "version": "1.1.0",
-  "description": "An ESLint plugin for projects that use Cypress",
+  "description": "An ESLint config for projects that use Cypress",
   "main": "index.js",
   "author": "Chris Breiding (chris@cypress.io)",
   "license": "MIT",
   "keywords": [
     "eslint",
-    "eslintplugin",
+    "eslintconfig",
     "cypress"
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cypress-io/eslint-plugin-cypress.git"
+    "url": "git+https://github.com/cypress-io/eslint-config-cypress.git"
   },
   "bugs": {
-    "url": "https://github.com/cypress-io/eslint-plugin-cypress/issues"
+    "url": "https://github.com/cypress-io/eslint-config-cypress/issues"
   },
-  "homepage": "https://github.com/cypress-io/eslint-plugin-cypress#readme",
+  "homepage": "https://github.com/cypress-io/eslint-config-cypress#readme",
   "peerDependencies": {
     "eslint": ">= 3.2.1"
   }


### PR DESCRIPTION
(I'm a student and this is my first PR anywhere, please excuse me if I do something wrong).

This doesn't seem to work currently because it's written like a [config](https://eslint.org/docs/developer-guide/shareable-configs), but calls itself a [plugin](https://eslint.org/docs/developer-guide/working-with-plugins).  A plugin takes a little extra setup, but you can do more with a it (e.g. define rules).

I just turned this into a config and it works, but if you expect to define rules in the future, please ignore this PR and structure it like a plugin instead (or I can try to).  Of course if you do accept the PR, you should also change the repo's name and description.