### PR TITLE
Adds a recommended config with new no-assigning-return-values rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,31 @@ Add an `.eslintrc.json` file to your `cypress` directory with the following:
   "plugins": [
     "cypress"
   ],
+  "extends": [
+    "plugin:cypress/recommended"
+  ],
   "env": {
     "cypress/globals": true
   }
 }
 ```
+
+## Rules
+
+Rules are grouped by category to help you understand their purpose.
+
+Rules with a check mark (✅) are enabled by default while using
+the `plugin:cypress/recommended` config.
+
+The --fix option on the command line automatically fixes problems reported by
+rules which have a wrench (🔧) below.
+
+
+### Possible Errors
+
+|    | Rule ID | Description |
+|:---|:--------|:------------|
+| ✅ | [no-assigning-return-values](./docs/rules/no-assigning-return-values.md) | Prevent assigning return values of cy calls |
 
 ## Chai and `no-unused-expressions`
 
@@ -49,3 +69,15 @@ In your `.eslintrc.json`:
   }
 }
 ```
+
+## Contribution Guide
+
+To add a new rule:
+  * Fork and clone this repository
+  * Generate a new rule (a [yeoman generator](https://github.com/eslint/generator-eslint) is available)
+  * Run `yarn start` or `npm start`
+  * Write test scenarios then implement logic
+  * Describe the rule in the generated `docs` file
+  * Make sure all tests are passing
+  * Add the rule to this README
+  * Create a PR

--- a/docs/rules/no-assigning-return-values.md
+++ b/docs/rules/no-assigning-return-values.md
@@ -1,0 +1,3 @@
+## No Assigning Return Values
+
+See [the Cypress Best Practices guide](https://docs.cypress.io/guides/references/best-practices.html#Assigning-Return-Values).

--- a/index.js
+++ b/index.js
@@ -1,6 +1,12 @@
 const globals = require('globals')
 
 module.exports = {
+  rules: {
+    'no-assigning-return-values': require('./lib/rules/no-assigning-return-values')
+  },
+  configs: {
+    recommended: require('./lib/config/recommended')
+  },
   environments: {
     globals: {
       globals: Object.assign(globals.browser, globals.mocha, {

--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  plugins: ['cypress'],
+  rules: {
+    'cypress/no-assigning-return-values': 'error'
+  }
+};

--- a/lib/rules/no-assigning-return-values.js
+++ b/lib/rules/no-assigning-return-values.js
@@ -1,0 +1,43 @@
+/**
+ * @fileoverview Prevent assigning return value of cy calls
+ * @author Elad Shahar
+ */
+
+'use strict';
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Prevent assigning return values of cy calls',
+      category: 'Possible Errors',
+      recommended: true,
+      url: 'https://docs.cypress.io/guides/references/best-practices.html#Assigning-Return-Values'
+    },
+    schema: [],
+    messages: {
+      unexpected: 'Do not assign the return value of a Cypress command'
+    }
+  },
+  create(context) {
+    return {
+      VariableDeclaration(node) {
+        if (node.declarations.some(isCypressCommandDeclaration)) {
+          context.report({ node, messageId: 'unexpected' });
+        }
+      }
+    };
+  }
+};
+
+function isCypressCommandDeclaration(declarator) {
+  if (!declarator)             { return; }
+  if (!declarator.init)        { return; }
+  if (!declarator.init.callee) { return; }
+
+  let object = declarator.init.callee.object;
+  while (object.callee) {
+    object = object.callee.object;
+  }
+
+  return object.name === 'cy';
+}

--- a/package.json
+++ b/package.json
@@ -26,18 +26,28 @@
   },
   "devDependencies": {
     "condition-circle": "1.5.0",
+    "eslint": "^5.7.0",
     "github-post-release": "1.13.1",
     "husky": "^0.14.3",
+    "jest": "^23.6.0",
     "semantic-release": "8.2.0",
     "simple-commit-message": "3.3.1"
   },
   "scripts": {
     "precommit": "eslint *.js",
-    "semantic-release": "semantic-release pre && npm publish --access public && semantic-release post"
+    "semantic-release": "semantic-release pre && npm publish --access public && semantic-release post",
+    "start": "yarn run test:watch",
+    "test": "jest",
+    "test-watch": "jest --watchAll"
   },
   "release": {
     "verifyConditions": "condition-circle",
     "analyzeCommits": "simple-commit-message",
     "generateNotes": "github-post-release"
+  },
+  "jest": {
+    "testMatch": [
+      "**/tests/**/*.js"
+    ]
   }
 }

--- a/tests/lib/rules/no-assigning-return-values.js
+++ b/tests/lib/rules/no-assigning-return-values.js
@@ -1,0 +1,31 @@
+"use strict";
+
+const rule = require('../../../lib/rules/no-assigning-return-values');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester();
+
+const errors = [{ messageId: 'unexpected' }];
+const parserOptions = { ecmaVersion: 6 };
+
+ruleTester.run('no-assigning-return-values', rule, {
+  valid: [
+    { code: 'var foo = true;', parserOptions },
+    { code: 'let foo = true;', parserOptions },
+    { code: 'const foo = true;', parserOptions },
+    { code: 'cy.get("foo");', parserOptions },
+    { code: 'cy.contains("foo").click();', parserOptions }
+  ],
+
+  invalid: [
+    { code: 'let a = cy.get("foo")', parserOptions, errors },
+    { code: 'const a = cy.get("foo")', parserOptions, errors },
+    { code: 'var a = cy.get("foo")', parserOptions, errors },
+
+    { code: 'let a = cy.contains("foo")', parserOptions, errors },
+    { code: 'let a = cy.window()', parserOptions, errors },
+    { code: 'let a = cy.wait("@something")', parserOptions, errors },
+
+    { code: 'let a = cy.contains("foo").click()', parserOptions, errors }
+  ]
+});


### PR DESCRIPTION
Adds an opinionated rule as suggested in #4. Tries to help with the ["Assigning Return Values" Best Practice described in the guide](https://docs.cypress.io/guides/references/best-practices.html#Assigning-Return-Values), something that bit me when I was first trying out Cypress.

When writing the rules and the folder layout, I tried to follow the practices described in [the ESLint guide](https://eslint.org/docs/developer-guide/working-with-rules). I also chose `jest` as the test runner but it can be easily switched to Mocha or whatever a maintainer would prefer.

I also updated the readme to instruct on how to add the recommended config, as well as a list of rules and instructions for developing new rules.

Known shortcomings:
  * This rule should catch any assignment type (`let`, `const`, `var`). However, it will not catch more complex assignment operations such as destructuring: `let [a, b] = [true, cypress.get('foo')]`.

Feedback/ideas on this or other potential rules welcome.

---

#### Example:

```js
// cypress/.eslintrc.js
module.exports = {
  plugins: ['cypress'],
  extends: 'plugin:cypress/recommended',
  env: {
    'cypress/globals': true
  }
}
```
```js
// cypress/test.js
describe('something', () => {
  it('might do a thing', () => {
    let a = cy.contains('Submit');
    a.click();
  });
});
```

```shell
$ yarn run eslint cypress/test.js

./cypress/test.js
  3:5  error  Do not assign the return value of a Cypress command  cypress/no-assigning-return-values

✖ 1 problem (1 error, 0 warnings)
```