### PR TITLE
add chai to globals

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports = {
         Cypress: false,
         expect: false,
         assert: false,
+        chai: false,
       }),
       parserOptions: {
         ecmaVersion: 2017,


### PR DESCRIPTION
on second thought, we should probably move `chai` onto `Cypress` and deprecate global `window.chai`