### PR TITLE
Avoid mutating eslint browser environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,13 +11,13 @@ module.exports = {
   },
   environments: {
     globals: {
-      globals: Object.assign(globals.browser, globals.mocha, {
+      globals: Object.assign({
         cy: false,
         Cypress: false,
         expect: false,
         assert: false,
         chai: false,
-      }),
+      }, globals.browser, globals.mocha),
       parserOptions: {
         ecmaVersion: 2019,
         sourceType: 'module',

--- a/tests/config.js
+++ b/tests/config.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const globals = require('globals')
+const config = require('../index.js')
+
+describe('environments globals', () => {
+  const env = config.environments.globals
+
+  it('should not mutate globals', () => {
+    expect(globals.browser).not.toHaveProperty('cy')
+    expect(globals.mocha).not.toHaveProperty('cy')
+  });
+
+  it('should include other globals', () => {
+    expect(env.globals).toEqual(expect.objectContaining(globals.browser))
+    expect(env.globals).toEqual(expect.objectContaining(globals.mocha))
+  });
+
+  it('should include cypress globals', () => {
+    expect(env.globals).toEqual(expect.objectContaining({
+      cy: false,
+      Cypress: false,
+    }))
+  });
+})


### PR DESCRIPTION
Currently the 'cypress/globals' env globals key is made into a copy
of the 'browser' env and changes its contents. Instead, make it a
distinct object.

Add test case that fails if the globals are tampered with on import.

Fixes cypress-io/eslint-plugin-cypress#26