### PR TITLE
make the rules config copy/pasteable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ You can add rules:
 ```json
 {
   "rules": {
-    "no-assigning-return-values": "error",
-    "no-unnecessary-waiting": "error",
-    "assertion-before-screenshot": "warn",
+    "cypress/no-assigning-return-values": "error",
+    "cypress/no-unnecessary-waiting": "error",
+    "cypress/assertion-before-screenshot": "warn",
   }
 }
 ```


### PR DESCRIPTION
In an eslintrc file, these need to have the plugin name prefixed.