### PR TITLE
chore(wording): fix ruleName of "require-data-selectors" test

### DIFF
--- a/tests/lib/rules/require-data-selectors.js
+++ b/tests/lib/rules/require-data-selectors.js
@@ -8,7 +8,7 @@ const ruleTester = new RuleTester()
 const errors = [{ messageId: 'unexpected' }]
 const parserOptions = { ecmaVersion: 6 }
 
-ruleTester.run('no-dynamic-id-classes', rule, {
+ruleTester.run('require-data-selectors', rule, {
   valid: [
     { code: 'cy.get(\'[data-cy=submit]\').click()', parserOptions },
     { code: 'cy.get(\'[data-QA=submit]\')', parserOptions },


### PR DESCRIPTION
When working on #32, I've seen that the rule name was not the good one.