### PR TITLE
Added handling for when the wait method is given an Identifier which has a number value

### DIFF
--- a/lib/rules/no-unnecessary-waiting.js
+++ b/lib/rules/no-unnecessary-waiting.js
@@ -21,8 +21,12 @@ module.exports = {
   create (context) {
     return {
       CallExpression (node) {
-        if (isCallingCyWait(node) && isNumberArgument(node)) {
-          context.report({ node, messageId: 'unexpected' })
+        if (isCallingCyWait(node)) {
+          const scope = context.getScope()
+
+          if (isIdentifierNumberConstArgument(node, scope) || isNumberArgument(node)) {
+            context.report({ node, messageId: 'unexpected' })
+          }
         }
       },
     }
@@ -41,4 +45,15 @@ function isNumberArgument (node) {
   return node.arguments.length > 0 &&
          node.arguments[0].type === 'Literal' &&
          typeof (node.arguments[0].value) === 'number'
+}
+
+function isIdentifierNumberConstArgument (node, scope) {
+  if (node.arguments[0].type !== 'Identifier') {
+    return false
+  }
+
+  const resolvedIdentifier = scope.resolve(node.arguments[0]).resolved
+  const IdentifierValue = resolvedIdentifier.defs[0].node.init.value
+
+  return typeof IdentifierValue === 'number'
 }

--- a/tests/lib/rules/no-unnecessary-waiting.js
+++ b/tests/lib/rules/no-unnecessary-waiting.js
@@ -18,11 +18,14 @@ ruleTester.run('no-unnecessary-waiting', rule, {
     { code: 'cy.clock(5000)', parserOptions },
     { code: 'cy.scrollTo(0, 10)', parserOptions },
     { code: 'cy.tick(500)', parserOptions },
+
+    { code: 'const someRequest="@someRequest"; cy.wait(someRequest)', parserOptions, errors },
   ],
 
   invalid: [
     { code: 'cy.wait(0)', parserOptions, errors },
     { code: 'cy.wait(100)', parserOptions, errors },
     { code: 'cy.wait(5000)', parserOptions, errors },
+    { code: 'const someNumber=500; cy.wait(someNumber)', parserOptions, errors },
   ],
 })


### PR DESCRIPTION
This is to handle cases where we have : 

const SLEEP = 500;

cy.wait(SLEEP)

This is still an unnecessary wait and should not be used.