### PR TITLE
Add rule: assertion before percy snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Rules with a check mark (✅) are enabled by default while using the `plugin:cyp
 | ✅ | [no-assigning-return-values](./docs/rules/no-assigning-return-values.md) | Prevent assigning return values of cy calls |
 | ✅ | [no-unnecessary-waiting](./docs/rules/no-unnecessary-waiting.md) | Prevent waiting for arbitrary time periods |
 | | [assertion-before-screenshot](./docs/rules/assertion-before-screenshot.md) | Ensure screenshots are preceded by an assertion |
+| | [assertion-before-percySnapshot](./docs/rules/assertion-before-percySnapshot.md) | Ensure [Percy snapshots](https://docs.percy.io/docs/cypress) are preceded by an assertion |
 
 ## Chai and `no-unused-expressions`
 

--- a/docs/rules/assertion-before-percySnapshot.md
+++ b/docs/rules/assertion-before-percySnapshot.md
@@ -1,0 +1,22 @@
+## Assertion Before percySnapshot
+
+If you take percySnapshots without assertions then you may get different percySnapshots depending on timing.
+
+For example, if clicking a button makes some network calls and upon success, renders something, then the percySnapshot may sometimes have the new render and sometimes not.
+
+This rule checks there is an assertion making sure your application state is correct before doing a percySnapshot. This makes sure the result of the percySnapshot will be consistent.
+
+Invalid:
+
+```
+cy.visit('myUrl');
+cy.percySnapshot();
+```
+
+Valid:
+
+```
+cy.visit('myUrl');
+cy.get('[data-test-id="my-element"]').should('be.visible');
+cy.percySnapshot();
+```

--- a/docs/rules/assertion-before-percySnapshot.md
+++ b/docs/rules/assertion-before-percySnapshot.md
@@ -1,10 +1,10 @@
 ## Assertion Before percySnapshot
 
-If you take percySnapshots without assertions then you may get different percySnapshots depending on timing.
+If you capture [Percy Snapshots](https://docs.percy.io/docs/cypress) without assertions then you may get different snapshots depending on timing.
 
-For example, if clicking a button makes some network calls and upon success, renders something, then the percySnapshot may sometimes have the new render and sometimes not.
+For example, if clicking a button makes some network calls and upon success, renders something, then the snapshot may sometimes have the new render and sometimes not.
 
-This rule checks there is an assertion making sure your application state is correct before doing a percySnapshot. This makes sure the result of the percySnapshot will be consistent.
+This rule checks there is an assertion making sure your application state is correct before taking a snapshot. This makes sure the result of the snapshot will be consistent.
 
 Invalid:
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ module.exports = {
     'no-assigning-return-values': require('./lib/rules/no-assigning-return-values'),
     'no-unnecessary-waiting': require('./lib/rules/no-unnecessary-waiting'),
     'assertion-before-screenshot': require('./lib/rules/assertion-before-screenshot'),
+    'assertion-before-percySnapshot': require('./lib/rules/assertion-before-percySnapshot'),
     'require-data-selectors': require('./lib/rules/require-data-selectors'),
   },
   configs: {

--- a/lib/rules/assertion-before-percySnapshot.js
+++ b/lib/rules/assertion-before-percySnapshot.js
@@ -1,5 +1,6 @@
 /**
  * @fileoverview Assert on the page state before taking a percySnapshot, so the percySnapshot is consistent
+ * @author Matt Charlton, copied from assertion-before-screenshot by Luke Page.
  */
 
 'use strict'

--- a/lib/rules/assertion-before-percySnapshot.js
+++ b/lib/rules/assertion-before-percySnapshot.js
@@ -1,0 +1,109 @@
+/**
+ * @fileoverview Assert on the page state before taking a percySnapshot, so the percySnapshot is consistent
+ */
+
+'use strict'
+
+const assertionCommands = [
+  // assertions
+  'should',
+  'and',
+  'contains',
+
+  // retries until it gets something
+  'get',
+
+  // not an assertion, but unlikely to require waiting for render
+  'scrollIntoView',
+  'scrollTo',
+];
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Assert on the page state before taking a percySnapshot, so the snapshot is consistent',
+      category: 'Possible Errors',
+      recommended: false,
+    },
+    schema: [],
+    messages: {
+      unexpected: 'Make an assertion on the page state before taking a percySnapshot',
+    },
+  },
+  create (context) {
+    return {
+      CallExpression (node) {
+        if (isCallingCyPercySnapshot(node) && !isPreviousAnAssertion(node)) {
+          context.report({ node, messageId: 'unexpected' })
+        }
+      },
+    }
+  },
+}
+
+function isRootCypress(node) {
+  while(node.type === 'CallExpression') {
+    if (node.callee.type !== 'MemberExpression') return false
+    if (node.callee.object.type === 'Identifier' &&
+        node.callee.object.name === 'cy') {
+      return true
+    }
+    node = node.callee.object
+  }
+  return false
+}
+
+function getPreviousInChain(node) {
+  return node.type === 'CallExpression' &&
+         node.callee.type === 'MemberExpression' &&
+         node.callee.object.type === 'CallExpression' &&
+         node.callee.object.callee.type === 'MemberExpression' &&
+         node.callee.object.callee.property.type === 'Identifier' &&
+         node.callee.object.callee.property.name
+}
+
+function getCallExpressionCypressCommand(node) {
+  return isRootCypress(node) &&
+         node.callee.property.type === 'Identifier' &&
+         node.callee.property.name
+}
+
+function isCallingCyPercySnapshot (node) {
+  return getCallExpressionCypressCommand(node) === 'percySnapshot'
+}
+
+function getPreviousCypressCommand(node) {
+  const previousInChain = getPreviousInChain(node)
+
+  if (previousInChain) {
+    return previousInChain
+  }
+
+  while(node.parent && !node.parent.body) {
+    node = node.parent
+  }
+
+  if (!node.parent || !node.parent.body) return null
+
+  const body = node.parent.body.type === 'BlockStatement' ? node.parent.body.body : node.parent.body
+
+  const index = body.indexOf(node)
+
+  // in the case of a function declaration it won't be found
+  if (index < 0) return null
+
+  if (index === 0) return getPreviousCypressCommand(node.parent);
+
+  const previousStatement = body[index - 1]
+
+  if (previousStatement.type !== 'ExpressionStatement' ||
+      previousStatement.expression.type !== 'CallExpression')
+    return null
+
+  return getCallExpressionCypressCommand(previousStatement.expression)
+}
+
+function isPreviousAnAssertion (node) {
+  const previousCypressCommand = getPreviousCypressCommand(node)
+  return assertionCommands.indexOf(previousCypressCommand) >= 0
+}

--- a/tests/lib/rules/assertion-before-percySnapshot.js
+++ b/tests/lib/rules/assertion-before-percySnapshot.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const rule = require('../../../lib/rules/assertion-before-percySnapshot')
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester()
+
+const errors = [{ messageId: 'unexpected' }]
+const parserOptions = { ecmaVersion: 6 }
+
+ruleTester.run('assertion-before-percySnapshot', rule, {
+  valid: [
+    { code: 'cy.get(".some-element"); cy.percySnapshot();', parserOptions },
+    { code: 'cy.get(".some-element").should("exist").percySnapshot();', parserOptions },
+    { code: 'cy.get(".some-element").should("exist").percySnapshot().click()', parserOptions, errors },
+    { code: 'cy.get(".some-element").should("exist"); if(true) cy.percySnapshot();', parserOptions },
+    { code: 'if(true) { cy.get(".some-element").should("exist"); cy.percySnapshot(); }', parserOptions },
+    { code: 'cy.get(".some-element").should("exist"); if(true) { cy.percySnapshot(); }', parserOptions },
+    { code: 'const a = () => { cy.get(".some-element").should("exist"); cy.percySnapshot(); }', parserOptions, errors },
+    { code: 'cy.get(".some-element").should("exist").and("be.visible"); cy.percySnapshot();', parserOptions },
+    { code: 'cy.get(".some-element").contains("Text"); cy.percySnapshot();', parserOptions },
+  ],
+
+  invalid: [
+    { code: 'cy.percySnapshot()', parserOptions, errors },
+    { code: 'cy.visit("somepage"); cy.percySnapshot();', parserOptions, errors },
+    { code: 'cy.custom(); cy.percySnapshot()', parserOptions, errors },
+    { code: 'cy.get(".some-element").click(); cy.percySnapshot()', parserOptions, errors },
+    { code: 'cy.get(".some-element").click().percySnapshot()', parserOptions, errors },
+    { code: 'if(true) { cy.get(".some-element").click(); cy.percySnapshot(); }', parserOptions, errors },
+    { code: 'cy.get(".some-element").click(); if(true) { cy.percySnapshot(); }', parserOptions, errors },
+    { code: 'cy.get(".some-element"); function a() { cy.percySnapshot(); }', parserOptions, errors },
+    { code: 'cy.get(".some-element"); const a = () => { cy.percySnapshot(); }', parserOptions, errors },
+  ],
+})


### PR DESCRIPTION
This is copied verbatim from https://github.com/cypress-io/eslint-plugin-cypress/pull/15 but checks for assertions before [cy.percySnapshot](https://docs.percy.io/docs/cypress) rather than cy.screenshot.