### PR TITLE
Catch chained wait

### DIFF
--- a/lib/rules/no-unnecessary-waiting.js
+++ b/lib/rules/no-unnecessary-waiting.js
@@ -33,10 +33,19 @@ module.exports = {
   },
 }
 
+function nodeIsCalledByCy (node) {
+  if (node.type === 'Identifier' && node.name === 'cy') return true
+
+  if (typeof node.callee === 'undefined' || typeof node.callee.object === 'undefined') {
+    return false
+  }
+
+  return nodeIsCalledByCy(node.callee.object)
+}
+
 function isCallingCyWait (node) {
   return node.callee.type === 'MemberExpression' &&
-         node.callee.object.type === 'Identifier' &&
-         node.callee.object.name === 'cy' &&
+         nodeIsCalledByCy(node) &&
          node.callee.property.type === 'Identifier' &&
          node.callee.property.name === 'wait'
 }
@@ -48,6 +57,8 @@ function isNumberArgument (node) {
 }
 
 function isIdentifierNumberConstArgument (node, scope) {
+  if (node.arguments.length === 0) return false
+
   if (node.arguments[0].type !== 'Identifier') return false
 
   const resolvedIdentifier = scope.resolve(node.arguments[0]).resolved

--- a/tests/lib/rules/no-unnecessary-waiting.js
+++ b/tests/lib/rules/no-unnecessary-waiting.js
@@ -10,6 +10,8 @@ const parserOptions = { ecmaVersion: 6 }
 
 ruleTester.run('no-unnecessary-waiting', rule, {
   valid: [
+    { code: 'foo.wait(10)', parserOptions },
+
     { code: 'cy.wait("@someRequest")', parserOptions },
     { code: 'cy.wait("@someRequest", { log: false })', parserOptions },
     { code: 'cy.wait("@someRequest").then((xhr) => xhr)', parserOptions },
@@ -33,5 +35,9 @@ ruleTester.run('no-unnecessary-waiting', rule, {
     { code: 'const someNumber=500; cy.wait(someNumber)', parserOptions, errors },
     { code: 'function customWait (ms = 1) { cy.wait(ms) }', parserOptions, errors },
     { code: 'const customWait = (ms = 1) => { cy.wait(ms) }', parserOptions, errors },
+
+    { code: 'cy.get(".some-element").wait(10)', parserOptions, errors },
+    { code: 'cy.get(".some-element").contains("foo").wait(10)', parserOptions, errors },
+    { code: 'const customWait = (ms = 1) => { cy.get(".some-element").wait(ms) }', parserOptions, errors },
   ],
 })


### PR DESCRIPTION
- Closes #35
- Closes #21

```js
// Already throws a lint error
cy.wait(100);

// Now throws a lint error
cy.foo().wait(100);
cy.foo().bar().wait(100);
```