### PR TITLE
Demo not needing `plugins` and rule-extending for friendly plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ In your `.eslintrc.json`:
 }
 ```
 
+Or you can simply add its `recommended` config:
+
+```json
+{
+  "extends": ["plugin:chai-friendly/recommended"]
+}
+```
+
 ## Contribution Guide
 
 To add a new rule:


### PR DESCRIPTION
No need for `plugins` and rule-extending if using recommended friendly config