### PR TITLE
fix: require data selectors support template literal

### DIFF
--- a/lib/rules/require-data-selectors.js
+++ b/lib/rules/require-data-selectors.js
@@ -39,7 +39,7 @@ function isCallingCyGet (node) {
 
 function isDataArgument (node) {
   return node.arguments.length > 0 &&
-  node.arguments[0].type === 'Literal' &&
+  (node.arguments[0].type === 'Literal' || node.arguments[0].type === 'TemplateLiteral') &&
   String(node.arguments[0].value).startsWith('[data-')
 
 }

--- a/lib/rules/require-data-selectors.js
+++ b/lib/rules/require-data-selectors.js
@@ -39,7 +39,8 @@ function isCallingCyGet (node) {
 
 function isDataArgument (node) {
   return node.arguments.length > 0 &&
-    ((node.arguments[0].type === 'Literal' && String(node.arguments[0].value).startsWith('[data-')) ||
-    (node.arguments[0].type === 'TemplateLiteral' && String(node.arguments[0].quasis[0].value.cooked).startsWith('[data-'))
+    (
+      (node.arguments[0].type === 'Literal' && String(node.arguments[0].value).startsWith('[data-')) ||
+      (node.arguments[0].type === 'TemplateLiteral' && String(node.arguments[0].quasis[0].value.cooked).startsWith('[data-'))
     )
 }

--- a/lib/rules/require-data-selectors.js
+++ b/lib/rules/require-data-selectors.js
@@ -39,7 +39,7 @@ function isCallingCyGet (node) {
 
 function isDataArgument (node) {
   return node.arguments.length > 0 &&
-  (node.arguments[0].type === 'Literal' || node.arguments[0].type === 'TemplateLiteral') &&
-  String(node.arguments[0].value).startsWith('[data-')
-
+    ((node.arguments[0].type === 'Literal' && String(node.arguments[0].value).startsWith('[data-')) ||
+    (node.arguments[0].type === 'TemplateLiteral' && String(node.arguments[0].quasis[0].value.cooked).startsWith('[data-'))
+    )
 }

--- a/tests/lib/rules/require-data-selectors.js
+++ b/tests/lib/rules/require-data-selectors.js
@@ -15,6 +15,7 @@ ruleTester.run('require-data-selectors', rule, {
     { code: 'cy.clock(5000)', parserOptions },
     { code: 'cy.scrollTo(0, 10)', parserOptions },
     { code: 'cy.tick(500)', parserOptions },
+    { code: 'cy.get(\`[data-cy=${1}]\`)', parserOptions },
   ],
 
   invalid: [
@@ -23,5 +24,6 @@ ruleTester.run('require-data-selectors', rule, {
     { code: 'cy.get(".btn-large").click()', parserOptions, errors },
     { code: 'cy.get(".btn-.large").click()', parserOptions, errors },
     { code: 'cy.get(".a")', parserOptions, errors },
+    { code: 'cy.get(\`[daedta-cy=${1}]\`)', parserOptions, errors },
   ],
 })


### PR DESCRIPTION
Closes https://github.com/cypress-io/eslint-plugin-cypress/issues/37

Check for nodeType to be `TemplateLiteral` and quasis cooked value to start with `[data-` 