### PR TITLE
fix: Allow aliases in require-data-selectors rule

### DIFF
--- a/lib/rules/require-data-selectors.js
+++ b/lib/rules/require-data-selectors.js
@@ -40,7 +40,13 @@ function isCallingCyGet (node) {
 function isDataArgument (node) {
   return node.arguments.length > 0 &&
     (
-      (node.arguments[0].type === 'Literal' && String(node.arguments[0].value).startsWith('[data-')) ||
-      (node.arguments[0].type === 'TemplateLiteral' && String(node.arguments[0].quasis[0].value.cooked).startsWith('[data-'))
+      (node.arguments[0].type === 'Literal' && isAliasOrDataSelector(String(node.arguments[0].value))) ||
+      (node.arguments[0].type === 'TemplateLiteral' && isAliasOrDataSelector(String(node.arguments[0].quasis[0].value.cooked)))
     )
+}
+
+function isAliasOrDataSelector (selector) {
+  return ['[data-', '@'].some(function (validValue) {
+    return selector.startsWith(validValue)
+  })
 }

--- a/tests/lib/rules/require-data-selectors.js
+++ b/tests/lib/rules/require-data-selectors.js
@@ -16,6 +16,8 @@ ruleTester.run('require-data-selectors', rule, {
     { code: 'cy.scrollTo(0, 10)', parserOptions },
     { code: 'cy.tick(500)', parserOptions },
     { code: 'cy.get(\`[data-cy=${1}]\`)', parserOptions },
+    { code: 'cy.get("@my-alias")', parserOptions, errors },
+    { code: 'cy.get(`@my-alias`)', parserOptions, errors },
   ],
 
   invalid: [


### PR DESCRIPTION
- Fixes #44

Hi !
This should fix #44.
It considers valid selectors that start with the character `@` as well as those that start with `[data-`.
I've added tests for both string and template literals.
Please let me know if I've missed anything or if there is a formatting problem.
Thanks for maintaining this eslint plugin ! :)