### PR TITLE
fix: allow assignment of children of whitelisted commands in no-assigning-return-values rule

### DIFF
--- a/lib/rules/no-assigning-return-values.js
+++ b/lib/rules/no-assigning-return-values.js
@@ -59,9 +59,9 @@ function isCypressCommandDeclaration (declarator) {
   }
   const commandName = get(declarator, 'init.callee.property.name')
 
-  const parent = get(object, "parent.property.name")
+  const parent = get(object, 'parent.property.name') || get(declarator, 'id.name')
 
-  if (commandName && (whitelistedCommands[commandName] || Object.keys(whitelistedCommands).includes(parent))) return
+  if (commandName && (whitelistedCommands[commandName] || whitelistedCommands[parent])) return
 
   return object.name === 'cy'
 }

--- a/lib/rules/no-assigning-return-values.js
+++ b/lib/rules/no-assigning-return-values.js
@@ -59,7 +59,9 @@ function isCypressCommandDeclaration (declarator) {
   }
   const commandName = get(declarator, 'init.callee.property.name')
 
-  if (commandName && whitelistedCommands[commandName]) return
+  const parent = get(object, "parent.property.name")
+
+  if (commandName && (whitelistedCommands[commandName] || Object.keys(whitelistedCommands).includes(parent))) return
 
   return object.name === 'cy'
 }

--- a/tests/lib/rules/no-assigning-return-values.js
+++ b/tests/lib/rules/no-assigning-return-values.js
@@ -16,6 +16,7 @@ ruleTester.run('no-assigning-return-values', rule, {
     { code: 'const foo = bar();', parserOptions },
     { code: 'const foo = bar().baz();', parserOptions },
     { code: 'const spy = cy.spy();', parserOptions },
+    { code: 'const spy = cy.spy().as();', parserOptions },
     { code: 'const stub = cy.stub();', parserOptions },
     { code: 'const result = cy.now();', parserOptions },
     { code: 'const state = cy.state();', parserOptions },


### PR DESCRIPTION
fixes #56 

This corrects the lint errors that are thrown with the bundled examples of cypress v4.6.

I don't know the API well enough to know if chaining more commands and returning the results is valid and should be covered here. But this is a start :)