### PR TITLE
fix: Replace deprecated scope.resolve method

### DIFF
--- a/lib/rules/no-unnecessary-waiting.js
+++ b/lib/rules/no-unnecessary-waiting.js
@@ -56,7 +56,8 @@ function isIdentifierNumberConstArgument (node, scope) {
 
   if (node.arguments[0].type !== 'Identifier') return false
 
-  const resolvedIdentifier = scope.resolve(node.arguments[0]).resolved
+  const identifier = node.arguments[0]
+  const resolvedIdentifier = scope.references.find((ref) => ref.identifier === identifier).resolved
   const definition = resolvedIdentifier.defs[0]
   const isVariable = definition.type === 'Variable'
 


### PR DESCRIPTION
Fixes #69 

As pointed out in the developer guide
https://eslint.org/docs/developer-guide/scope-manager-interface#deprecated-members-2

scope.resolve method is deprecated. For that reason it was not implemented
in `typescript-eslint/typescript-eslint` and `no-unnecessary-waiting` rule
fails with version 4.x of the typescript eslint parser.

The eslint developer guide suggest to use `scope.references.find` instead.