### PR TITLE
Disable browser globals by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = {
         expect: false,
         assert: false,
         chai: false,
-      }, globals.browser, globals.mocha),
+      }, globals.mocha),
       parserOptions: {
         ecmaVersion: 2019,
         sourceType: 'module',


### PR DESCRIPTION
You shouldn't have to include browser globals by default. Usually what this means is that in the entirety of the project, window (for example) is considered a viable global variable.