### PR TITLE
fix: Fix crashing bug in no-force rule when using spread operator

### DIFF
--- a/lib/rules/no-force.js
+++ b/lib/rules/no-force.js
@@ -42,7 +42,7 @@ module.exports = {
 
       return node.arguments && node.arguments.length &&
       node.arguments.some((arg) => {
-        return arg.type === 'ObjectExpression' && arg.properties.some((propNode) => propNode.key.name === 'force')
+        return arg.type === 'ObjectExpression' && arg.properties.some((propNode) => propNode.key && propNode.key.name === 'force')
       })
     }
 

--- a/tests/lib/rules/no-force.js
+++ b/tests/lib/rules/no-force.js
@@ -9,7 +9,7 @@ const rule = require('../../../lib/rules/no-force')
 const RuleTester = require('eslint').RuleTester
 
 const errors = [{ messageId: 'unexpected' }]
-const parserOptions = { ecmaVersion: 6 }
+const parserOptions = { ecmaVersion: 2018 }
 
 //------------------------------------------------------------------------------
 // Tests
@@ -24,12 +24,13 @@ ruleTester.run('no-force', rule, {
     { code: `cy.get('button').click({multiple: true})`, parserOptions },
     { code: `cy.get('button').dblclick()`, parserOptions },
     { code: `cy.get('input').type('somth')`, parserOptions },
-    { code: `cy.get('input').type('somth', {anyoption: true})`, parserOptions, errors },
-    { code: `cy.get('input').trigger('click', {anyoption: true})`, parserOptions, errors },
-    { code: `cy.get('input').rightclick({anyoption: true})`, parserOptions, errors },
-    { code: `cy.get('input').check()`, parserOptions, errors },
-    { code: `cy.get('input').select()`, parserOptions, errors },
-    { code: `cy.get('input').focus()`, parserOptions, errors },
+    { code: `cy.get('input').type('somth', {anyoption: true})`, parserOptions },
+    { code: `cy.get('input').trigger('click', {anyoption: true})`, parserOptions },
+    { code: `cy.get('input').rightclick({anyoption: true})`, parserOptions },
+    { code: `cy.get('input').check()`, parserOptions },
+    { code: `cy.get('input').select()`, parserOptions },
+    { code: `cy.get('input').focus()`, parserOptions },
+    { code: `cy.document().trigger("keydown", { ...event })`, parserOptions },
   ],
 
   invalid: [


### PR DESCRIPTION
This was causing my Eslint to crash, I think on the cy.document({ log: false }) nodes if someone is interested in that, so just quickly fixed it