### PR TITLE
Add no cy.pause() command rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ You can add rules:
     "cypress/no-unnecessary-waiting": "error",
     "cypress/assertion-before-screenshot": "warn",
     "cypress/no-force": "warn",
-    "cypress/no-async-tests": "error"
+    "cypress/no-async-tests": "error",
+    "cypress/no-pause": "error"
   }
 }
 ```
@@ -123,6 +124,7 @@ Rules with a check mark (✅) are enabled by default while using the `plugin:cyp
 |     | [no-force](./docs/rules/no-force.md)                                       | Disallow using `force: true` with action commands               |
 |     | [assertion-before-screenshot](./docs/rules/assertion-before-screenshot.md) | Ensure screenshots are preceded by an assertion                 |
 |     | [require-data-selectors](./docs/rules/require-data-selectors.md)           | Only allow data-\* attribute selectors (require-data-selectors) |
+|     | [no-pause](./docs/rules/no-pause.md)           | Disallow `cy.pause()` parent command |
 
 ## Chai and `no-unused-expressions`
 

--- a/docs/rules/no-pause.md
+++ b/docs/rules/no-pause.md
@@ -1,0 +1,16 @@
+## Do not use `cy.pause` command
+
+It is recommended to remove [cy.pause](https://on.cypress.io/pause) command before committing the specs to avoid other developers getting unexpected results.
+
+Invalid:
+
+```js
+cy.pause();
+```
+
+Valid:
+
+```js
+// only the parent cy.pause command is detected
+cy.get('selector').pause();
+```

--- a/lib/rules/no-pause.js
+++ b/lib/rules/no-pause.js
@@ -26,13 +26,15 @@ module.exports = {
     // Helpers
     //----------------------------------------------------------------------
     function isCallingPause (node) {
-      return node.property &&
-        node.property.type === 'Identifier' &&
-        node.property.name === 'pause'
+      return node.callee &&
+        node.callee.property &&
+        node.callee.property.type === 'Identifier' &&
+        node.callee.property.name === 'pause'
     }
 
     function isCypressCall (node) {
-      return node.callee.type === 'MemberExpression' &&
+      return node.callee &&
+        node.callee.type === 'MemberExpression' &&
         node.callee.object.type === 'Identifier' &&
         node.callee.object.name === 'cy'
     }

--- a/lib/rules/no-pause.js
+++ b/lib/rules/no-pause.js
@@ -1,0 +1,54 @@
+'use strict'
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Disallow using of \'cy.pause\' calls',
+      category: 'Possible Errors',
+      recommended: false,
+    },
+    fixable: null, // or "code" or "whitespace"
+    schema: [],
+    messages: {
+      unexpected: 'Do not use cy.pause command',
+    },
+  },
+
+  create (context) {
+
+    // variables should be defined here
+
+    //----------------------------------------------------------------------
+    // Helpers
+    //----------------------------------------------------------------------
+    function isCallingPause (node) {
+      return node.property &&
+        node.property.type === 'Identifier' &&
+        node.property.name === 'pause'
+    }
+
+    function isCypressCall (node) {
+      return node.callee.type === 'MemberExpression' &&
+        node.callee.object.type === 'Identifier' &&
+        node.callee.object.name === 'cy'
+    }
+
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
+
+    return {
+
+      CallExpression (node) {
+        if (isCypressCall(node) && isCallingPause(node)) {
+          context.report({ node, messageId: 'unexpected' })
+        }
+      },
+
+    }
+  },
+}

--- a/tests/lib/rules/no-pause.js
+++ b/tests/lib/rules/no-pause.js
@@ -1,0 +1,33 @@
+'use strict'
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/no-pause')
+
+const RuleTester = require('eslint').RuleTester
+
+const errors = [{ messageId: 'unexpected' }]
+const parserOptions = { ecmaVersion: 2018 }
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+let ruleTester = new RuleTester()
+
+ruleTester.run('no-pause', rule, {
+
+  valid: [
+    // for now, we do not detect .pause() child command
+    { code: `cy.get('button').pause()`, parserOptions },
+    { code: `pause()`, parserOptions },
+    { code: `cy.get('button').dblclick()`, parserOptions },
+  ],
+
+  invalid: [
+    { code: `cy.pause()`, parserOptions, errors },
+    { code: `cy.pause({ log: false })`, parserOptions, errors },
+  ],
+})

--- a/tests/lib/rules/no-pause.js
+++ b/tests/lib/rules/no-pause.js
@@ -15,7 +15,7 @@ const parserOptions = { ecmaVersion: 2018 }
 // Tests
 //------------------------------------------------------------------------------
 
-let ruleTester = new RuleTester()
+const ruleTester = new RuleTester()
 
 ruleTester.run('no-pause', rule, {
 


### PR DESCRIPTION
Partial implementation for #74 which disallows the parent `cy.pause()` command. We have occasionally left `cy.pause` command in the specs which always surprises the other developers when they use `cypress open`.