### PR TITLE
fix: Properly export "no-pause" rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ module.exports = {
     'assertion-before-screenshot': require('./lib/rules/assertion-before-screenshot'),
     'require-data-selectors': require('./lib/rules/require-data-selectors'),
     'no-force': require('./lib/rules/no-force'),
+    'no-pause': require('./lib/rules/no-pause'),
   },
   configs: {
     recommended: require('./lib/config/recommended'),


### PR DESCRIPTION
Just noticed this new rule and wanted to try it out, but it seemed to be not actually used
https://github.com/cypress-io/eslint-plugin-cypress/pull/85