### PR TITLE
Handle ImportBindings in `no-unnecessary-waiting` rule

### DIFF
--- a/lib/rules/no-unnecessary-waiting.js
+++ b/lib/rules/no-unnecessary-waiting.js
@@ -60,7 +60,6 @@ function isIdentifierNumberConstArgument (node, scope) {
   const resolvedIdentifier = scope.references.find((ref) => ref.identifier === identifier).resolved
   const definition = resolvedIdentifier.defs[0]
   const isVariable = definition.type === 'Variable'
-  const isImportBinding = definition.type === 'ImportBinding'
 
   // const amount = 1000 or const amount = '@alias'
   // cy.wait(amount)
@@ -73,9 +72,7 @@ function isIdentifierNumberConstArgument (node, scope) {
   // import { WAIT } from './constants'
   // cy.wait(WAIT)
   // we don't know if WAIT is a number or alias '@someRequest', so don't fail
-  if (isImportBinding) {
-    return false
-  }
+  if (definition.type === 'ImportBinding') return false
 
   const param = definition.node.params[definition.index]
 

--- a/lib/rules/no-unnecessary-waiting.js
+++ b/lib/rules/no-unnecessary-waiting.js
@@ -70,8 +70,9 @@ function isIdentifierNumberConstArgument (node, scope) {
     return typeof definition.node.init.value === 'number'
   }
 
-  // import { WAIT_TIME } from './constants'
-  // cy.wait(WAIT_TIME)
+  // import { WAIT } from './constants'
+  // cy.wait(WAIT)
+  // we don't know if WAIT is a number or alias '@someRequest', so don't fail
   if (isImportBinding) {
     return false
   }

--- a/lib/rules/no-unnecessary-waiting.js
+++ b/lib/rules/no-unnecessary-waiting.js
@@ -60,6 +60,7 @@ function isIdentifierNumberConstArgument (node, scope) {
   const resolvedIdentifier = scope.references.find((ref) => ref.identifier === identifier).resolved
   const definition = resolvedIdentifier.defs[0]
   const isVariable = definition.type === 'Variable'
+  const isImportBinding = definition.type === 'ImportBinding'
 
   // const amount = 1000 or const amount = '@alias'
   // cy.wait(amount)
@@ -67,6 +68,12 @@ function isIdentifierNumberConstArgument (node, scope) {
     if (!definition.node.init) return false
 
     return typeof definition.node.init.value === 'number'
+  }
+
+  // import { WAIT_TIME } from './constants'
+  // cy.wait(WAIT_TIME)
+  if (isImportBinding) {
+    return false
   }
 
   const param = definition.node.params[definition.index]

--- a/tests/lib/rules/no-unnecessary-waiting.js
+++ b/tests/lib/rules/no-unnecessary-waiting.js
@@ -6,7 +6,7 @@ const RuleTester = require('eslint').RuleTester
 const ruleTester = new RuleTester()
 
 const errors = [{ messageId: 'unexpected' }]
-const parserOptions = { ecmaVersion: 6 }
+const parserOptions = { ecmaVersion: 6, sourceType: 'module' }
 
 ruleTester.run('no-unnecessary-waiting', rule, {
   valid: [
@@ -26,6 +26,11 @@ ruleTester.run('no-unnecessary-waiting', rule, {
     { code: 'const customWait = (alias = "@someRequest") => { cy.wait(alias) }', parserOptions, errors },
     { code: 'function customWait (ms) { cy.wait(ms) }', parserOptions, errors },
     { code: 'const customWait = (ms) => { cy.wait(ms) }', parserOptions, errors },
+
+    { code: 'import BAR_BAZ from "bar-baz"; cy.wait(BAR_BAZ)', parserOptions },
+    { code: 'import { FOO_BAR } from "foo-bar"; cy.wait(FOO_BAR)', parserOptions },
+    { code: 'import * as wildcard from "wildcard"; cy.wait(wildcard.value)', parserOptions },
+    { code: 'import { NAME as OTHER_NAME } from "rename"; cy.wait(OTHER_NAME)', parserOptions },
 
     // disable the eslint rule
     {


### PR DESCRIPTION
This PR adds proper handling for ImportBindings in `no-unnecessary-waiting` rule to prevent reporting codes like this:

```js
// We don't know if WAIT is a number or alias '@someRequest'
import { WAIT } from './constnats'

cy.wait(WAIT)
```

It's similar to the existing case with function arguments where we cannot see the type of the argument. Similarly, we cannot know the type of import binding.

```js
  // function wait (amount) { cy.wait(amount) }
  // we can't know the type of value, so don't fail
  if (!param || param.type !== 'AssignmentPattern') return false
```

Resolves https://github.com/cypress-io/eslint-plugin-cypress/issues/43