### PR TITLE
fix: Solve unsafe to chain command does not exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const globals = require('globals')
 module.exports = {
   rules: {
     'no-assigning-return-values': require('./lib/rules/no-assigning-return-values'),
+    'unsafe-to-chain-command': require('./lib/rules/unsafe-to-chain-command'),
     'no-unnecessary-waiting': require('./lib/rules/no-unnecessary-waiting'),
     'no-async-tests': require('./lib/rules/no-async-tests'),
     'assertion-before-screenshot': require('./lib/rules/assertion-before-screenshot'),


### PR DESCRIPTION
This is kinda urgent because if you sync the latest package you get error saying the rule doesn't exist, for not being registered properly:

`Definition for rule 'cypress/unsafe-to-chain-command' was not found `