### PR TITLE
fix: Wait incorrectly reported as unsafe to chain

### DIFF
--- a/lib/rules/unsafe-to-chain-command.js
+++ b/lib/rules/unsafe-to-chain-command.js
@@ -41,7 +41,7 @@ function isRootCypress (node) {
 
 function isActionUnsafeToChain (node) {
   // commands listed in the documentation with text: 'It is unsafe to chain further commands that rely on the subject after xxx'
-  const unsafeToChainActions = ['blur', 'clear', 'click', 'check', 'dblclick', 'each', 'focus', 'rightclick', 'screenshot', 'scrollIntoView', 'scrollTo', 'select', 'selectFile', 'spread', 'submit', 'type', 'trigger', 'uncheck', 'wait', 'within']
+  const unsafeToChainActions = ['blur', 'clear', 'click', 'check', 'dblclick', 'each', 'focus', 'rightclick', 'screenshot', 'scrollIntoView', 'scrollTo', 'select', 'selectFile', 'spread', 'submit', 'type', 'trigger', 'uncheck', 'within']
 
   return node.callee && node.callee.property && node.callee.property.type === 'Identifier' && unsafeToChainActions.includes(node.callee.property.name)
 }


### PR DESCRIPTION
Wait command [is documented as unsafe to chain](https://docs.cypress.io/api/commands/wait#When-given-a-time-argument), but that might be an oversight in the documentation since there are documented use cases for wait action.