### PR TITLE
fix unsafe-to-chain-command

### DIFF
--- a/tests/lib/rules/unsafe-to-chain-command.js
+++ b/tests/lib/rules/unsafe-to-chain-command.js
@@ -8,7 +8,7 @@ const ruleTester = new RuleTester()
 const errors = [{ messageId: 'unexpected' }]
 const parserOptions = { ecmaVersion: 6 }
 
-ruleTester.run('action-ends-chain', rule, {
+ruleTester.run('unsafe-to-chain-command', rule, {
   valid: [
     { code: 'cy.get("new-todo").type("todo A{enter}"); cy.get("new-todo").type("todo B{enter}"); cy.get("new-todo").should("have.class", "active");', parserOptions },
   ],


### PR DESCRIPTION
Hopefully this should solve this error:

```bash
error  Definition for rule 'cypress/unsafe-to-chain-command' was not found  cypress/unsafe-to-chain-command
```
