### PR TITLE
chore: revert merge for semantic release

### DIFF
--- a/lib/rules/unsafe-to-chain-command.js
+++ b/lib/rules/unsafe-to-chain-command.js
@@ -19,7 +19,7 @@ const unsafeToChainActions = [
   'check',
   'dblclick',
   'each',
-  'focus$',
+  'focus',
   'rightclick',
   'screenshot',
   'scrollIntoView',

--- a/tests/lib/rules/unsafe-to-chain-command.js
+++ b/tests/lib/rules/unsafe-to-chain-command.js
@@ -32,11 +32,6 @@ ruleTester.run('action-ends-chain', rule, {
       errors,
     },
     {
-      code: 'cy.get("new-todo").focus().should("have.class", "active");',
-      parserOptions,
-      errors,
-    },
-    {
       code: 'cy.get("new-todo").customType("todo A{enter}").customClick();',
       parserOptions,
       errors,

--- a/tests/lib/rules/unsafe-to-chain-command.js
+++ b/tests/lib/rules/unsafe-to-chain-command.js
@@ -14,10 +14,6 @@ ruleTester.run('action-ends-chain', rule, {
       code: 'cy.get("new-todo").type("todo A{enter}"); cy.get("new-todo").type("todo B{enter}"); cy.get("new-todo").should("have.class", "active");',
       parserOptions,
     },
-    {
-      code: 'cy.focused().should("be.visible");',
-      parserOptions,
-    },
   ],
 
   invalid: [


### PR DESCRIPTION
going to revert #142 and re apply commits as a single squash merged commit to trigger semantic release on the re apply PR