### PR TITLE
fix: unsafe-to-chain-command: Fix the false positive of 'focus' regex matching 'focused'

### DIFF
--- a/lib/rules/unsafe-to-chain-command.js
+++ b/lib/rules/unsafe-to-chain-command.js
@@ -19,7 +19,7 @@ const unsafeToChainActions = [
   'check',
   'dblclick',
   'each',
-  'focus',
+  'focus$',
   'rightclick',
   'screenshot',
   'scrollIntoView',

--- a/tests/lib/rules/unsafe-to-chain-command.js
+++ b/tests/lib/rules/unsafe-to-chain-command.js
@@ -32,6 +32,11 @@ ruleTester.run('action-ends-chain', rule, {
       errors,
     },
     {
+      code: 'cy.get("new-todo").focus().should("have.class", "active");',
+      parserOptions,
+      errors,
+    },
+    {
       code: 'cy.get("new-todo").customType("todo A{enter}").customClick();',
       parserOptions,
       errors,

--- a/tests/lib/rules/unsafe-to-chain-command.js
+++ b/tests/lib/rules/unsafe-to-chain-command.js
@@ -14,6 +14,10 @@ ruleTester.run('action-ends-chain', rule, {
       code: 'cy.get("new-todo").type("todo A{enter}"); cy.get("new-todo").type("todo B{enter}"); cy.get("new-todo").should("have.class", "active");',
       parserOptions,
     },
+    {
+      code: 'cy.focused().should("be.visible");',
+      parserOptions,
+    },
   ],
 
   invalid: [


### PR DESCRIPTION
re applies #142 as a `fix` commit when we squash-merge this commit in