### PR TITLE
feat: Implement no-exclusive-tests rule

### DIFF
--- a/lib/rules/no-exclusive-tests.js
+++ b/lib/rules/no-exclusive-tests.js
@@ -1,0 +1,26 @@
+module.exports = {
+  create(context) {
+    return {
+      CallExpression(node) {
+        const callee = node.callee;
+        const testDescriptions = ['context', 'describe', 'it'];
+        const forbiddenValues = ['only', 'skip'];
+
+        if (
+          callee.type === 'MemberExpression' &&
+          testDescriptions.includes(callee.object.name) &&
+          forbiddenValues.includes(callee.property.name)
+        ) {
+          const filePath = context.getFilename();
+
+          if (filePath.match(/\.cytest\.tsx$|cypress\/integration\/.*\.spec\.ts$/)) {
+            context.report({
+              node: node,
+              message: 'Do not use .only or .skip in tests',
+            });
+          }
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
This rule prevents the usage of .skip and .only in tests. 
(If approved, I can write the test cases for the rule)