### PR TITLE
chore: make lint script Windows compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "scripts": {
     "precommit": "npm run lint",
-    "lint": "eslint '*.js' '**/**/*.js'",
+    "lint": "eslint \"*.js\" \"**/**/*.js\"",
     "lint-fix": "npm run lint -- --fix",
     "semantic-release": "semantic-release",
     "start": "yarn run test-watch",


### PR DESCRIPTION
## Issue

The script `lint` fails to run on Microsoft Windows operating systems. The error is:

```text
$ npm run lint

> eslint-plugin-cypress@0.0.0-development lint
> eslint '*.js' '**/**/*.js'


Oops! Something went wrong! :(

ESLint: 5.16.0.
No files matching the pattern "'*.js'" were found.
Please check for typing mistakes in the pattern.
```

## Change

The single-quotes in the script definition `lint` are changed to double-quotes and escaped for cross-compatibility with Windows.

## Verification

On Ubuntu `22.04.4` LTS and on Windows 11 with Node.js `16.15.0` execute

```shell
npm ci
npm run lint
```

The output from the lint script should be as follows with no errors reported:

```shell
$ npm run lint

> eslint-plugin-cypress@0.0.0-development lint
> eslint "*.js" "**/**/*.js"
```
