### PR TITLE
ci: remove dependency on semantic-release npm

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -27,7 +27,7 @@ jobs:
       - checkout
       - run:
           name: Install dependencies
-          command: npm install
+          command: npm ci
       - run:
           name: Lint code
           command: npm run lint
@@ -39,10 +39,13 @@ jobs:
       - checkout
       - run:
           name: Install dependencies
-          command: npm install
+          command: npm ci
+      - run:
+          name: Install ESLint 4
+          command: npm install eslint@4
       - run:
           name: Test ESLint 4
-          command: npm run test:v4
+          command: npm test
 
   test-v5:
     docker:
@@ -51,10 +54,13 @@ jobs:
       - checkout
       - run:
           name: Install dependencies
-          command: npm install
+          command: npm ci
+      - run:
+          name: Install ESLint 5
+          command: npm install eslint@5
       - run:
           name: Test ESLint 5
-          command: npm run test
+          command: npm test
 
   test-v6:
     docker:
@@ -63,10 +69,13 @@ jobs:
       - checkout
       - run:
           name: Install dependencies
-          command: npm install
+          command: npm ci
+      - run:
+          name: Install ESLint 6
+          command: npm install eslint@6
       - run:
           name: Test ESLint 6
-          command: npm run test:v6
+          command: npm test
 
   release:
     docker:
@@ -75,7 +84,7 @@ jobs:
       - checkout
       - run:
           name: Install dependencies
-          command: npm install
+          command: npm ci
       - run:
           name: Run semantic release
           command: npm run semantic-release


### PR DESCRIPTION
- relates to issue #163 

## Issue

- Using the following test scripts in CircleCI results in failure if the npm module semantic-release is updated (see failure in PR https://github.com/cypress-io/eslint-plugin-cypress/pull/162):

- `"test:v4": "npm i eslint@4.x && npm run test"`
- `"test:v6": "npm i eslint@6.x && npm run test"`

This combination is causing an incompatible version of npm to be used. This problematic npm version is provided through the npm module `semantic-release`.

## Changes

1. Convert calls from `npm install` to `npm ci`.

    `npm ci` was released with [npm@5.7.0](https://github.com/npm/npm/releases/tag/v5.7.0) in Feb 2018

2. Make installation and test of alternate versions into two separate steps.