### PR TITLE
test: drop testing of ESLint 4

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,13 +5,11 @@ workflows:
   main:
     jobs:
       - lint
-      - test-v4
       - test-v5
       - test-v6
       - release:
           requires:
             - lint
-            - test-v4
             - test-v5
             - test-v6
           filters:
@@ -31,21 +29,6 @@ jobs:
       - run:
           name: Lint code
           command: npm run lint
-
-  test-v4:
-    docker:
-      - image: cimg/node:20.12.2
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: npm ci
-      - run:
-          name: Install ESLint 4
-          command: npm install eslint@4
-      - run:
-          name: Test ESLint 4
-          command: npm test
 
   test-v5:
     docker:

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "semantic-release": "semantic-release",
     "start": "yarn run test-watch",
     "test": "jest",
-    "test:v4": "npm i eslint@4.x && npm run test",
     "test:v6": "npm i eslint@6.x && npm run test",
     "test-watch": "jest --watchAll",
     "prepare": "husky install"


### PR DESCRIPTION
related to issues:

- #166
- #153
- #157
- closes #163

## Issue

[@cypress/eslint-plugin-dev@3.2.0](https://github.com/cypress-io/eslint-plugin-dev/tree/v3.2.0) configured in this repo's `devDependencies` contains `peerDependencies`:

```json
    "@typescript-eslint/parser": ">= 1.11.0"
    "eslint": ">= 3.2.1 < 6"
```

however

[@typescript-eslint/parser@1.11.0](https://github.com/typescript-eslint/typescript-eslint/blob/v1.11.0/packages/parser) is only compatible with ESLint `5`:

```json
  "eslint": "^5.0.0"
```

This rules out the supported use of ESLint `4` for dev linting tests in the repository.

## Change

Remove tests for ESLint `4`.

The last release of ESLint 4.x was [eslint@4.19.1](https://github.com/eslint/eslint/releases/tag/v4.19.1) released on March 22, 2018, more than 6 years ago. The current release is [eslint@9.0.0](https://github.com/eslint/eslint/releases/tag/v9.0.0) released on Apr 5, 2024.

This change does not prevent `eslint-plugin-cypress` being installed and used with ESLint `4` therefore it is not a breaking change for end-users.

There is an outdated note in [README > Rules](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/README.md#rules) referring to ESLint `4.x`. The [issue #14](https://github.com/cypress-io/eslint-plugin-cypress/issues/14), being referred to, is however already resolved. This should be cleaned up in a later migration step as the repo is moved towards supporting ESLint `8.x` correctly.

> **NOTE**: These rules currently require eslint 5.0 or greater. If you would like support added for eslint 4.x, please 👍  [this issue](https://github.com/cypress-io/eslint-plugin-cypress/issues/14).
