### PR TITLE
docs: move README contributing section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing to cypress-io/eslint-plugin-cypress
+
+Thanks for taking the time to contribute! :smile:
+
+To add a new rule:
+  * Fork and clone this repository
+  * Generate a new rule (a [yeoman generator](https://github.com/eslint/generator-eslint) is available)
+  * Run `yarn start` or `npm start`
+  * Write test scenarios then implement logic
+  * Describe the rule in the generated `docs` file
+  * Make sure all tests are passing
+  * Add the rule to the [README](README.md) file
+  * Create a PR
+
+Use the following commit message conventions: https://github.com/semantic-release/semantic-release#commit-message-format

--- a/README.md
+++ b/README.md
@@ -159,16 +159,6 @@ Or you can simply add its `recommended` config:
 }
 ```
 
-## Contribution Guide
+## Contributing
 
-To add a new rule:
-  * Fork and clone this repository
-  * Generate a new rule (a [yeoman generator](https://github.com/eslint/generator-eslint) is available)
-  * Run `yarn start` or `npm start`
-  * Write test scenarios then implement logic
-  * Describe the rule in the generated `docs` file
-  * Make sure all tests are passing
-  * Add the rule to this README
-  * Create a PR
-
-Use the following commit message conventions: https://github.com/semantic-release/semantic-release#commit-message-format
+Please see our [Contributing Guideline](./CONTRIBUTING.md) which explains how to contribute rules or other fixes and features to the repo.


### PR DESCRIPTION
## Situation

The [README > Contribution Guide](https://github.com/cypress-io/eslint-plugin-cypress?tab=readme-ov-file#contribution-guide) is a section in the README file.

Other Cypress.io repositories such as [cypress-io/cypress](https://github.com/cypress-io/cypress), [cypress-io/cypress-docker-images](https://github.com/cypress-io/cypress-docker-images), [cypress-io/cypress-example-kitchensink](https://github.com/cypress-io/cypress-example-kitchensink), [cypress-io/cypress-documentation](https://github.com/cypress-io/cypress-documentation), etc. use a separate `CONTRIBUTING.md` file.

## Changes

Move the [README > Contribution Guide](https://github.com/cypress-io/eslint-plugin-cypress?tab=readme-ov-file#contribution-guide) section to a separate file `CONTRIBUTING.md` and link the [README > Contribution Guide](https://github.com/cypress-io/eslint-plugin-cypress?tab=readme-ov-file#contribution-guide) to the file.

## Next steps

There are some inaccuracies and missing steps in the guide. I plan to propose corrections in a separate PR at a later date.