### PR TITLE
feat: support eslint v7 & v8 instead of ">= 3.2.1"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Note: If you installed ESLint globally then you must also install `eslint-plugin
 
 ## Installation
 
+Prerequisites: [ESLint](https://www.npmjs.com/package/eslint) `v7` or `v8`. ESLint `v9` is **not** supported yet.
+
 ```sh
 npm install eslint-plugin-cypress --save-dev
 ```
@@ -114,8 +116,6 @@ For more, see the [ESLint rules](https://eslint.org/docs/user-guide/configuring/
 These rules enforce some of the [best practices recommended for using Cypress](https://on.cypress.io/best-practices).
 
 Rules with a check mark (✅) are enabled by default while using the `plugin:cypress/recommended` config.
-
-**NOTE**: These rules currently require eslint 5.0 or greater. If you would like support added for eslint 4.x, please 👍  [this issue](https://github.com/cypress-io/eslint-plugin-cypress/issues/14).
 
 |     | Rule ID                                                                    | Description                                                     |
 | :-- | :------------------------------------------------------------------------- | :-------------------------------------------------------------- |

--- a/circle.yml
+++ b/circle.yml
@@ -5,15 +5,13 @@ workflows:
   main:
     jobs:
       - lint
-      - test-v5
-      - test-v6
       - test-v7
+      - test-v8
       - release:
           requires:
             - lint
-            - test-v5
-            - test-v6
             - test-v7
+            - test-v8
           filters:
             branches:
               only:
@@ -32,36 +30,6 @@ jobs:
           name: Lint code
           command: npm run lint
 
-  test-v5:
-    docker:
-      - image: cimg/node:20.12.2
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: npm ci
-      - run:
-          name: Install ESLint 5
-          command: npm install eslint@5
-      - run:
-          name: Test ESLint 5
-          command: npm test
-
-  test-v6:
-    docker:
-      - image: cimg/node:20.12.2
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: npm ci
-      - run:
-          name: Install ESLint 6
-          command: npm install eslint@6
-      - run:
-          name: Test ESLint 6
-          command: npm test
-
   test-v7:
     docker:
       - image: cimg/node:20.12.2
@@ -75,6 +43,21 @@ jobs:
           command: npm install eslint@7
       - run:
           name: Test ESLint 7
+          command: npm test
+
+  test-v8:
+    docker:
+      - image: cimg/node:20.12.2
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: npm ci
+      - run:
+          name: Install ESLint 8
+          command: npm install eslint@8
+      - run:
+          name: Test ESLint 8
           command: npm test
 
   release:

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "semantic-release": "19.0.3"
       },
       "peerDependencies": {
-        "eslint": ">= 3.2.1"
+        "eslint": ">=7 <9"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/cypress-io/eslint-plugin-cypress#readme",
   "peerDependencies": {
-    "eslint": ">= 3.2.1"
+    "eslint": ">=7 <9"
   },
   "dependencies": {
     "globals": "^13.20.0"
@@ -44,7 +44,6 @@
     "semantic-release": "semantic-release",
     "start": "yarn run test-watch",
     "test": "jest",
-    "test:v6": "npm i eslint@6.x && npm run test",
     "test-watch": "jest --watchAll",
     "prepare": "husky install"
   }


### PR DESCRIPTION
BREAKING CHANGE: Support ESLint v7 and v8 only

- closes https://github.com/cypress-io/eslint-plugin-cypress/issues/89
- closes https://github.com/cypress-io/eslint-plugin-cypress/issues/175

## Issue

The `eslint-plugin-cypress` plugin currently defines `peerDependencies` of `"eslint": ">= 3.2.1"`. This includes versions of ESLint `v3`, `v4` and `v9` which are not compatible with the current latest version of `eslint-plugin-cypress@2.15.2` (including its other `peerDependencies`). ESLint `v8` cannot be linted by `@cypress/eslint-plugin-dev` and replacement linting recommended by [Linting a Plugin](https://eslint.org/docs/latest/extend/plugins#linting-a-plugin) only covers ESLint `v7` and above.

The intersection of supportable combinations is ESLint `v7` and `v8` only.

## Change

Support ESlint `v7` & `v8` instead of all versions from ESLint `3.2.1` upwards.

To allow this repo to use up-to-date linting plugins and prepare the path for migration to ESLint `v9` this PR triggers a new major version which supports ESLint `v7` and `v8` only. Earlier legacy versions `v3` - `v6` are dropped. The as-yet incompatible ESLint `v9` is blocked from inadvertent usage. (See [ESLint v9.0.0 released](https://eslint.org/blog/2024/04/eslint-v9.0.0-released/) announcement dated Apr 5, 2024.)

| eslint version | last release | action |
| -------------- | ------------ | ------ |
| 3.2.1          | 8 years ago  | block  |
| v4             | 6 years ago  | block  |
| v5             | 5 years ago  | block  |
| v6             | 4 years ago  | block  |
| v7             | 3 years ago  | keep   |
| v8             | 4 months ago | keep   |
| v9             | 13 days ago  | block  |

- The [README](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/README.md) document now says that ESLint `v7` or `v8` are prerequisites and that ESLint `v9` is not supported yet. References to ESLint `v4` and `v5` are removed.
- [package.json](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/package.json) `peerDependencies` now define<br>  `"eslint": ">=7 <9"`
- [circle.yml](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/circle.yml) runs
  - `test-v7`
  - `test-v8`

## Verification

Ubuntu `22.04.4` LTS Node.js `20.12.2`

```shell
mkdir eslint-plugin-cypress-test
cd eslint-plugin-cypress-test
git init
npm init -y
npm install eslint@8 MikeMcC399/eslint-plugin-cypress#support-eslint-7-and-8 -D
```

shows:

```shell
$ npm install eslint@8 MikeMcC399/eslint-plugin-cypress#support-eslint-7-and-8 -D

added 100 packages, and audited 101 packages in 14s

23 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

The following correctly reports an error:

```shell
npm install eslint@9 MikeMcC399/eslint-plugin-cypress#support-eslint-7-and-8 -D
```

```text
$ npm install eslint@9 MikeMcC399/eslint-plugin-cypress#support-eslint-7-and-8 -D
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: eslint-plugin-dev-test@1.0.0
npm ERR! Found: eslint@9.0.0
npm ERR! node_modules/eslint
npm ERR!   dev eslint@"9" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer eslint@">=7 <9" from eslint-plugin-cypress@0.0.0-development
npm ERR! node_modules/eslint-plugin-cypress
npm ERR!   dev eslint-plugin-cypress@"MikeMcC399/eslint-plugin-cypress#support-eslint-7-and-8" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```
