### PR TITLE
chore: harmonize and describe jest usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,10 @@ Thanks for taking the time to contribute! :smile:
 To add a new rule:
   * Fork and clone this repository
   * Generate a new rule (a [yeoman generator](https://github.com/eslint/generator-eslint) is available)
-  * Run `yarn start` or `npm start`
   * Write test scenarios then implement logic
   * Describe the rule in the generated `docs` file
+  * Run `npm test` to run [Jest](https://jestjs.io/) or
+  * Run `npm start` to run [Jest](https://jestjs.io/) in [watchAll](https://jestjs.io/docs/cli#--watchall) mode where it remains active and reruns when source changes are made
   * Make sure all tests are passing
   * Add the rule to the [README](README.md) file
   * Create a PR

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lint": "eslint \"*.js\" \"**/**/*.js\"",
     "lint-fix": "npm run lint -- --fix",
     "semantic-release": "semantic-release",
-    "start": "yarn run test-watch",
+    "start": "npm run test-watch",
     "test": "jest",
     "test-watch": "jest --watchAll",
     "prepare": "husky install"


### PR DESCRIPTION
## Issue

1. The script `start` is defined in package.json as `yarn run test-watch` using the Yarn package manager.
https://github.com/cypress-io/eslint-plugin-cypress/blob/455dc131960e6a55a24c18960e49e893c8862e6f/package.json#L45
2. [CONTRIBUTING.md](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/CONTRIBUTING.md) invites to use
> * Run `yarn start` or `npm start`

The use of Yarn seems out of place, as the rest of the repository, such as [circle.yml](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/circle.yml) is using npm not Yarn. The repo is locked with [package-lock.json](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/package-lock.json). There is no `yarn.lock` in the repository.

3. Only the `start` script is mentioned. The `test` script is not mentioned.

## Change

1. Harmonize on the use of npm and remove Yarn references and usage.
2. Describe the two scripts `start` and `test`

## Verification

Execute

```bash
npm test
```

and confirm that Jest runs successfully and exits.

Execute

```bash
npm start
```

and confirm that Jest is run in watch mode. Terminate Jest.
