### PR TITLE
docs: add mocha instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,44 @@ Rules with a check mark (✅) are enabled by default while using the `plugin:cyp
 |     | [require-data-selectors](./docs/rules/require-data-selectors.md)           | Only allow data-\* attribute selectors (require-data-selectors) |
 |     | [no-pause](./docs/rules/no-pause.md)           | Disallow `cy.pause()` parent command |
 
+## Mocha and Chai
+
+Cypress is built on top of [Mocha](https://on.cypress.io/guides/references/bundled-libraries#Mocha) and [Chai](https://on.cypress.io/guides/references/bundled-libraries#Chai). See the following sections for information on using ESLint plugins [eslint-plugin-mocha](https://www.npmjs.com/package/eslint-plugin-mocha) and [eslint-plugin-chai-friendly](https://www.npmjs.com/package/eslint-plugin-chai-friendly) together with `eslint-plugin-cypress`.
+
+## Mocha `.only` and `.skip`
+
+During test spec development, [Mocha exclusive tests](https://mochajs.org/#exclusive-tests) `.only` or [Mocha inclusive tests](https://mochajs.org/#inclusive-tests) `.skip` may be used to control which tests are executed, as described in the Cypress documentation [Excluding and Including Tests](https://on.cypress.io/guides/core-concepts/writing-and-organizing-tests#Excluding-and-Including-Tests). To apply corresponding rules, you can install and use [eslint-plugin-mocha](https://www.npmjs.com/package/eslint-plugin-mocha). The rule [mocha/no-exclusive-tests](https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/docs/rules/no-exclusive-tests.md) detects the use of `.only` and the [mocha/no-skipped-tests](https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/docs/rules/no-skipped-tests.md) rule detects the use of `.skip`:
+
+```sh
+npm install --save-dev eslint-plugin-mocha
+```
+
+In your `.eslintrc.json`:
+
+```json
+{
+  "plugins": [
+    "cypress",
+    "mocha"
+  ],
+  "rules": {
+    "mocha/no-exclusive-tests": "warn",
+    "mocha/no-skipped-tests": "warn"
+  }
+}
+```
+
+Or you can simply use the `cypress/recommended` and `mocha/recommended` configurations together, for example:
+
+```json
+{
+  "extends": [
+    "plugin:cypress/recommended",
+    "plugin:mocha/recommended"
+  ]
+}
+```
+
 ## Chai and `no-unused-expressions`
 
 Using an assertion such as `expect(value).to.be.true` can fail the ESLint rule `no-unused-expressions` even though it's not an error in this case. To fix this, you can install and use [eslint-plugin-chai-friendly](https://www.npmjs.com/package/eslint-plugin-chai-friendly).


### PR DESCRIPTION
- closes #180

## Issue

Users have requested linting support to detect `.only` and `.skip` constructs in Cypress test specs and have submitted issues and PRs to have these rules built in to `eslint-plugin-cypress`. Adding these rules into the Cypress plugin would however duplicate the following existing working and comprehensive rules in [eslint-plugin-mocha](https://www.npmjs.com/package/eslint-plugin-mocha):

- [mocha/no-exclusive-tests](https://github.com/lo1tuma/eslint-plugin-mocha/blob/HEAD/docs/rules/no-exclusive-tests.md) to warn about the use of  `describe.only`, `it.only`, `suite.only`, `test.only`, `context.only` and `specify.only` within the source code.
- [mocha/no-skipped-tests](https://github.com/lo1tuma/eslint-plugin-mocha/blob/a936f2ace2191d0b26b70a34e19711e6a4252659/docs/rules/no-skipped-tests.md) to warn about the use of `describe.skip`, `it.skip`, `suite.skip`, `test.skip`, `context.skip`, `specify.skip`, `xdescribe`, `xit`, `xcontext` and `xspecify` within the source code.

The alternative to adding the rules to `eslint-plugin-cypress` is to install and use [eslint-plugin-mocha](https://www.npmjs.com/package/eslint-plugin-mocha) together with `eslint-plugin-cypress`.

## Change

A section is added to the [README](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/README.md) to describe how to use the [eslint-plugin-mocha](https://www.npmjs.com/package/eslint-plugin-mocha) plugin together with the `eslint-plugin-cypress` plugin in order to detect `.only` and `.skip` usage.

## Verification

Verify using the working example of `eslint-plugin-cypress` and `eslint-plugin-mocha` in the [cypress-io/cypress-example-kitchensink](https://github.com/cypress-io/cypress-example-kitchensink) repo (see [.eslintrc](https://github.com/cypress-io/cypress-example-kitchensink/blob/master/.eslintrc) for the [ESLint 8.x config file](https://eslint.org/docs/v8.x/use/configure/configuration-files)).

```shell
git clone https://github.com/cypress-io/cypress-example-kitchensink
cd cypress-example-kitchensink
npm ci
npm install eslint@8 eslint-plugin-mocha@latest -D
```

Modify the file `cypress/e2e/2-advanced-examples/actions.cy.js` to add an exclusive test and a skipped test:
- Change `context` to `context.only`
- Change the first occurence of `it` to `it.skip`

and execute:

```shell
npx eslint cypress
```

confirm that linting errors are reported:

```text
$ npx eslint cypress

   3:9  error    Unexpected exclusive mocha test  mocha/no-exclusive-tests
  10:6  warning  Unexpected skipped mocha test    mocha/no-skipped-tests

✖ 2 problems (1 error, 1 warning)
```
