### PR TITLE
fix: convert deprecated context calls

### DIFF
--- a/lib/rules/no-async-before.js
+++ b/lib/rules/no-async-before.js
@@ -28,7 +28,7 @@ module.exports = {
                 && node.arguments.length >= 2
                 && node.arguments[1].async === true
     }
-    const { sourceCode = { } } = context
+    const sourceCode = context.sourceCode ?? context.getSourceCode()
 
     return {
       Identifier (node) {

--- a/lib/rules/no-async-before.js
+++ b/lib/rules/no-async-before.js
@@ -28,11 +28,14 @@ module.exports = {
                 && node.arguments.length >= 2
                 && node.arguments[1].async === true
     }
+    const { sourceCode = { } } = context
 
     return {
       Identifier (node) {
         if (node.name === 'cy' || node.name === 'Cypress') {
-          const ancestors = context.getAncestors()
+          const ancestors = sourceCode.getAncestors
+            ? sourceCode.getAncestors(node)
+            : context.getAncestors()
           const asyncTestBlocks = ancestors
           .filter((n) => n.type === 'CallExpression')
           .filter(isBeforeBlock)

--- a/lib/rules/no-async-tests.js
+++ b/lib/rules/no-async-tests.js
@@ -28,7 +28,7 @@ module.exports = {
                 && node.arguments.length >= 2
                 && node.arguments[1].async === true
     }
-    const { sourceCode = { } } = context
+    const sourceCode = context.sourceCode ?? context.getSourceCode()
 
     return {
       Identifier (node) {

--- a/lib/rules/no-async-tests.js
+++ b/lib/rules/no-async-tests.js
@@ -28,11 +28,14 @@ module.exports = {
                 && node.arguments.length >= 2
                 && node.arguments[1].async === true
     }
+    const { sourceCode = { } } = context
 
     return {
       Identifier (node) {
         if (node.name === 'cy' || node.name === 'Cypress') {
-          const ancestors = context.getAncestors()
+          const ancestors = sourceCode.getAncestors
+            ? sourceCode.getAncestors(node)
+            : context.getAncestors()
           const asyncTestBlocks = ancestors
           .filter((n) => n.type === 'CallExpression')
           .filter(isTestBlock)

--- a/lib/rules/no-unnecessary-waiting.js
+++ b/lib/rules/no-unnecessary-waiting.js
@@ -15,7 +15,7 @@ module.exports = {
     },
   },
   create (context) {
-    const { sourceCode = { } } = context
+    const sourceCode = context.sourceCode ?? context.getSourceCode()
 
     return {
       CallExpression (node) {

--- a/lib/rules/no-unnecessary-waiting.js
+++ b/lib/rules/no-unnecessary-waiting.js
@@ -15,10 +15,14 @@ module.exports = {
     },
   },
   create (context) {
+    const { sourceCode = { } } = context
+
     return {
       CallExpression (node) {
         if (isCallingCyWait(node)) {
-          const scope = context.getScope()
+          const scope = sourceCode.getScope
+            ? sourceCode.getScope(node)
+            : context.getScope()
 
           if (isIdentifierNumberConstArgument(node, scope) || isNumberArgument(node)) {
             context.report({ node, messageId: 'unexpected' })


### PR DESCRIPTION
- closes https://github.com/cypress-io/eslint-plugin-cypress/issues/154

## Issue

-  [no-unnecessary-waiting](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/lib/rules/no-unnecessary-waiting.js) rule is using `context.getScope()`
-  [no-async-tests](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/lib/rules/no-async-tests.js) rule is using `context.getAncestors()`
-  [no-async-before](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/lib/rules/no-async-before.js) rule is using `context.getAncestors()`

These methods are deprecated in ESLint `8.x` ([eslint@8.50.0](https://github.com/eslint/eslint/releases/tag/v8.5.0) and later `8.x` releases), causing warnings, and removed in ESLint `9.x` ([eslint@9.0.0](https://github.com/eslint/eslint/releases/tag/v9.0.0)), causing failures.

## Change

See ESLint Blog [Preparing your custom rules for ESLint v9.0.0](https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/) Sep 26, 2023.

The above mentioned rules are converted according to:

- [context.getScope()](https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/#context.getscope()) => `sourceCode.getScope`
- [context.getAncestors()](https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/#context.getancestors()) => `sourceCode.getAncestors`

~~except that instead of the suggested code line~~
~~`const { sourceCode } = context;`~~
~~the following is used~~
~~`const { sourceCode = {} } = context;`~~
~~to avoid failure on earlier versions, such as ESLint `8.23.0`.~~

Edit: the recommendations have been revised and the above line of code is now
`const sourceCode = context.sourceCode ?? context.getSourceCode();`

## Verification

On Ubuntu `22.04.4` LTS with Node.js `20.12.2` LTS. For ESLint `v7` and `v8` execute `npx jest`.

```shell
npm ci
npm uninstall eslint-plugin-eslint-plugin eslint-plugin-n
npm install eslint@7
npx jest
npm install eslint@8
npx jest
```
