### PR TITLE
ci: display exact eslint version in circleci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -27,6 +27,9 @@ jobs:
           name: Install dependencies
           command: npm ci
       - run:
+          name: Show ESLint version
+          command: npx eslint --version
+      - run:
           name: Lint code
           command: npm run lint
 
@@ -42,6 +45,9 @@ jobs:
           name: Install ESLint 7
           command: npm install eslint@7
       - run:
+          name: Show ESLint version
+          command: npx eslint --version
+      - run:
           name: Test ESLint 7
           command: npm test
 
@@ -56,6 +62,9 @@ jobs:
       - run:
           name: Install ESLint 8
           command: npm install eslint@8
+      - run:
+          name: Show ESLint version
+          command: npx eslint --version
       - run:
           name: Test ESLint 8
           command: npm test


### PR DESCRIPTION
## Issue

When alternative versions of ESLint are installed by the [circle.yml](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/circle.yml) workflow, the version of ESLint is not logged. This makes troubleshooting more difficult.

In the current transition phase, whilst dependencies are being updated in incremental steps, it is unavoidable that peer dependency errors are logged. npm does not make it clear which version of ESLint it has chosen for installation.

- See also https://github.com/cypress-io/eslint-plugin-cypress/pull/182#issuecomment-2069416309

## Change

The exact version of ESLint is shown with the [CLI option `--version`](https://eslint.org/docs/latest/use/command-line-interface#-v---version), for example `v8.57.0`:

```shell
npx eslint --version
```
