### PR TITLE
chore: add meta.type to rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,7 +16,6 @@
   ],
   "rules": {
     "eslint-plugin/require-meta-schema": "off",
-    "eslint-plugin/require-meta-type": "off",
     "n/no-extraneous-require": [
       "error",
       {

--- a/lib/rules/assertion-before-screenshot.js
+++ b/lib/rules/assertion-before-screenshot.js
@@ -16,6 +16,7 @@ const assertionCommands = [
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'Assert on the page state before taking a screenshot, so the screenshot is consistent',
       category: 'Possible Errors',

--- a/lib/rules/no-assigning-return-values.js
+++ b/lib/rules/no-assigning-return-values.js
@@ -17,6 +17,7 @@ function get (obj, propertyString = '') {
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'Prevent assigning return values of cy calls',
       category: 'Possible Errors',

--- a/lib/rules/no-async-before.js
+++ b/lib/rules/no-async-before.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'Prevent using async/await in Cypress before methods',
       category: 'Possible Errors',

--- a/lib/rules/no-async-tests.js
+++ b/lib/rules/no-async-tests.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'Prevent using async/await in Cypress test cases',
       category: 'Possible Errors',

--- a/lib/rules/no-force.js
+++ b/lib/rules/no-force.js
@@ -6,6 +6,7 @@
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Disallow using of \'force: true\' option for click and type calls',
       category: 'Possible Errors',

--- a/lib/rules/no-pause.js
+++ b/lib/rules/no-pause.js
@@ -6,6 +6,7 @@
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Disallow using of \'cy.pause\' calls',
       category: 'Possible Errors',

--- a/lib/rules/no-unnecessary-waiting.js
+++ b/lib/rules/no-unnecessary-waiting.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'Prevent waiting for arbitrary time periods',
       category: 'Possible Errors',

--- a/lib/rules/require-data-selectors.js
+++ b/lib/rules/require-data-selectors.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Use data-* attributes to provide context to your selectors and insulate them from CSS or JS changes https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements',
       category: 'Possible Errors',

--- a/lib/rules/unsafe-to-chain-command.js
+++ b/lib/rules/unsafe-to-chain-command.js
@@ -69,6 +69,7 @@ const getDefaultOptions = (context) => {
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: DESCRIPTION,
       category: 'Possible Errors',


### PR DESCRIPTION
- supports resolution of issue https://github.com/cypress-io/eslint-plugin-cypress/issues/184

## Issue

The `plugin:eslint-plugin/recommended` rules of [eslint-plugin-eslint-plugin](https://www.npmjs.com/package/eslint-plugin-eslint-plugin) include the [eslint-plugin/require-meta-type](https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/require-meta-type.md) rule. This rule currently fails for all of the Cypress rules if enabled, since none of these has a `meta.type` defined.

## Documentation reference

According to the ESLint documentation [Rule Structure](https://eslint.org/docs/latest/extend/custom-rules#rule-structure):

> `meta`: (`object`) Contains metadata for the rule:
>
> * `type`: (`string`) Indicates the type of rule, which is one of `"problem"`, `"suggestion"`, or `"layout"`:
>
>    * `"problem"`: The rule is identifying code that either will cause an error or may cause a confusing behavior. Developers should consider this a high priority to resolve.
>    * `"suggestion"`: The rule is identifying something that could be done in a better way but no errors will occur if the code isn't changed.
>    * `"layout"`: The rule cares primarily about whitespace, semicolons, commas, and parentheses, all the parts of the program that determine how the code looks rather than how it executes. These rules work on parts of the code that aren't specified in the AST.

## Changes

Add `meta.type` to all rules and enable the rule [eslint-plugin/require-meta-type](https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/require-meta-type.md).

| Rule ID                                                                                                                                  | Description                                                     | Type       |
| :--------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------- | ---------- |
| [assertion-before-screenshot](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/docs/rules/assertion-before-screenshot.md) | Ensure screenshots are preceded by an assertion                 | problem    |
| [no-assigning-return-values](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/docs/rules/no-assigning-return-values.md)   | Prevent assigning return values of cy calls                     | problem    |
| [no-unnecessary-waiting](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/docs/rules/no-unnecessary-waiting.md)           | Prevent waiting for arbitrary time periods                      | problem    |
| [no-async-before](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/docs/rules/no-async-before.md)                         | Prevent using async/await in Cypress test case                  | problem    |
| [no-async-tests](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/docs/rules/no-async-tests.md)                           | Prevent using async/await in Cypress test case                  | problem    |
| [unsafe-to-chain-command](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/docs/rules/unsafe-to-chain-command.md)         | Prevent chaining from unsafe to chain commands                  | problem    |
| [no-force](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/docs/rules/no-force.md)                                       | Disallow using `force: true` with action commands               | suggestion |
| [no-pause](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/docs/rules/no-pause.md)                                       | Disallow `cy.pause()` parent command                            | suggestion |
| [require-data-selectors](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/docs/rules/require-data-selectors.md)           | Only allow data-\* attribute selectors (require-data-selectors) | suggestion |

