### PR TITLE
chore: standardize meta.url property

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,12 @@
     "plugin:mocha/recommended"
   ],
   "rules": {
+    "eslint-plugin/require-meta-docs-url": [
+      "error",
+      {
+        "pattern": "https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/{{name}}.md"
+      }
+    ],
     "n/no-extraneous-require": [
       "error",
       {

--- a/lib/rules/assertion-before-screenshot.js
+++ b/lib/rules/assertion-before-screenshot.js
@@ -21,6 +21,7 @@ module.exports = {
       description: 'Assert on the page state before taking a screenshot, so the screenshot is consistent',
       category: 'Possible Errors',
       recommended: false,
+      url: 'https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/assertion-before-screenshot.md',
     },
     schema: [],
     messages: {

--- a/lib/rules/no-assigning-return-values.js
+++ b/lib/rules/no-assigning-return-values.js
@@ -22,7 +22,7 @@ module.exports = {
       description: 'Prevent assigning return values of cy calls',
       category: 'Possible Errors',
       recommended: true,
-      url: 'https://on.cypress.io/best-practices#Assigning-Return-Values',
+      url: 'https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-assigning-return-values.md',
     },
     schema: [],
     messages: {

--- a/lib/rules/no-async-before.js
+++ b/lib/rules/no-async-before.js
@@ -7,6 +7,7 @@ module.exports = {
       description: 'Prevent using async/await in Cypress before methods',
       category: 'Possible Errors',
       recommended: true,
+      url: 'https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-async-before.md',
     },
     schema: [],
     messages: {

--- a/lib/rules/no-async-tests.js
+++ b/lib/rules/no-async-tests.js
@@ -7,6 +7,7 @@ module.exports = {
       description: 'Prevent using async/await in Cypress test cases',
       category: 'Possible Errors',
       recommended: true,
+      url: 'https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-async-tests.md',
     },
     schema: [],
     messages: {

--- a/lib/rules/no-force.js
+++ b/lib/rules/no-force.js
@@ -11,6 +11,7 @@ module.exports = {
       description: 'Disallow using of \'force: true\' option for click and type calls',
       category: 'Possible Errors',
       recommended: false,
+      url: 'https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-force.md',
     },
     fixable: null, // or "code" or "whitespace"
     schema: [],

--- a/lib/rules/no-pause.js
+++ b/lib/rules/no-pause.js
@@ -11,6 +11,7 @@ module.exports = {
       description: 'Disallow using of \'cy.pause\' calls',
       category: 'Possible Errors',
       recommended: false,
+      url: 'https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-pause.md',
     },
     fixable: null, // or "code" or "whitespace"
     schema: [],

--- a/lib/rules/no-unnecessary-waiting.js
+++ b/lib/rules/no-unnecessary-waiting.js
@@ -7,7 +7,7 @@ module.exports = {
       description: 'Prevent waiting for arbitrary time periods',
       category: 'Possible Errors',
       recommended: true,
-      url: 'https://on.cypress.io/best-practices#Unnecessary-Waiting',
+      url: 'https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-unnecessary-waiting.md',
     },
     schema: [],
     messages: {

--- a/lib/rules/require-data-selectors.js
+++ b/lib/rules/require-data-selectors.js
@@ -4,10 +4,10 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Use data-* attributes to provide context to your selectors and insulate them from CSS or JS changes https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements',
+      description: 'Use data-* attributes to provide context to your selectors and insulate them from CSS or JS changes',
       category: 'Possible Errors',
       recommended: false,
-      url: 'https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements',
+      url: 'https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/require-data-selectors.md',
     },
     schema: [],
     messages: {

--- a/lib/rules/unsafe-to-chain-command.js
+++ b/lib/rules/unsafe-to-chain-command.js
@@ -74,7 +74,7 @@ module.exports = {
       description: DESCRIPTION,
       category: 'Possible Errors',
       recommended: true,
-      url: 'https://docs.cypress.io/guides/core-concepts/retry-ability#Actions-should-be-at-the-end-of-chains-not-the-middle',
+      url: 'https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/unsafe-to-chain-command.md',
     },
     schema: [schema],
     messages: {


### PR DESCRIPTION
- supports resolution of issue https://github.com/cypress-io/eslint-plugin-cypress/issues/184

## Issue

The [eslint-plugin/require-meta-docs-url](https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/require-meta-docs-url.md) rule of [eslint-plugin-eslint-plugin](https://www.npmjs.com/package/eslint-plugin-eslint-plugin) requires that the `meta.docs.url` property is populated.

Rules with no  `meta.docs.url` property defined:

| Rule document                                                                                                                            |
| :--------------------------------------------------------------------------------------------------------------------------------------- |
| [assertion-before-screenshot](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/docs/rules/assertion-before-screenshot.md) |
| [no-async-before](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/docs/rules/no-async-before.md)                         |
| [no-async-tests](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/docs/rules/no-async-tests.md)                           |
| [no-force](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/docs/rules/no-force.md)                                       |
| [no-pause](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/docs/rules/no-pause.md)                                       |


The following rule documents contain no detailed contents and instead refer to URLs on the Cypress documentation site:

| Rule document                                                                                                                          | Links to                                                                                                         |
| :------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------- |
| [no-assigning-return-values](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/docs/rules/no-assigning-return-values.md) | https://on.cypress.io/best-practices#Assigning-Return-Values                                                     |
| [no-unnecessary-waiting](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/docs/rules/no-unnecessary-waiting.md)         | https://on.cypress.io/best-practices#Unnecessary-Waiting                                                         |
| [unsafe-to-chain-command](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/docs/rules/unsafe-to-chain-command.md)       | https://docs.cypress.io/guides/core-concepts/retry-ability#Actions-should-be-at-the-end-of-chains-not-the-middle |

This single rule document contains both detailed contents and a link to the corresponding Cypress documentation site best practices page:

| Rule document                                                                                                                  | Links to                                                                         |
| :----------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------- |
| [require-data-selectors](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/docs/rules/require-data-selectors.md) | https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements |

## Documentation reference

According to the ESLint documentation [Rule Structure](https://eslint.org/docs/latest/extend/custom-rules#rule-structure):

> * `docs`: (`object`) Properties often used for documentation generation and tooling. Required for core rules and optional for custom rules. Custom rules can include additional properties here as needed.
>
>    * `url`: (`string`) Specifies the URL at which the full documentation can be accessed. Code editors often use this to provide a helpful link on highlighted rule violations.

## Change

Implement the rule [eslint-plugin/require-meta-docs-url](https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/require-meta-docs-url.md) using the `pattern` option to populate the `meta.docs.url` property consistently for all rules:

```json
    "eslint-plugin/require-meta-docs-url": [
      "error",
      {
        "pattern": "https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/{{name}}.md"
      }
    ],
```
