### PR TITLE
feat: apply no-pause rule recursively

### DIFF
--- a/docs/rules/no-pause.md
+++ b/docs/rules/no-pause.md
@@ -9,11 +9,11 @@ Examples of **incorrect** code for this rule:
 
 ```js
 cy.pause();
+cy.get('selector').pause();
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
-// only the parent cy.pause command is detected
-cy.get('selector').pause();
+cy.get('selector')
 ```

--- a/lib/rules/no-pause.js
+++ b/lib/rules/no-pause.js
@@ -35,12 +35,15 @@ module.exports = {
     }
 
     function isCypressCall (node) {
-      return node.callee &&
-        node.callee.type === 'MemberExpression' &&
-        node.callee.object.type === 'Identifier' &&
-        node.callee.object.name === 'cy'
+      if (!node.callee || node.callee.type !== 'MemberExpression') {
+        return false;
+      }
+      if (node.callee.object.type === 'Identifier' && node.callee.object.name === 'cy') {
+        return true;
+      }
+      return isCypressCall(node.callee.object);
     }
-
+    
     //----------------------------------------------------------------------
     // Public
     //----------------------------------------------------------------------

--- a/tests/lib/rules/no-pause.js
+++ b/tests/lib/rules/no-pause.js
@@ -20,14 +20,18 @@ const ruleTester = new RuleTester()
 ruleTester.run('no-pause', rule, {
 
   valid: [
-    // for now, we do not detect .pause() child command
-    { code: `cy.get('button').pause()`, parserOptions },
     { code: `pause()`, parserOptions },
     { code: `cy.get('button').dblclick()`, parserOptions },
   ],
-
+  
   invalid: [
     { code: `cy.pause()`, parserOptions, errors },
     { code: `cy.pause({ log: false })`, parserOptions, errors },
+    { code: `cy.get('button').pause()`, parserOptions, errors },
+    { 
+      code: `cy.get('a').should('have.attr', 'href').and('match', /dashboard/).pause()`, 
+      parserOptions, 
+      errors 
+    }
   ],
 })


### PR DESCRIPTION
## Issue

The `cypress/no-pause` rule only applies to a parent node. 

## Changes

Convert the `isCypressCall` function into a recursive function to detect chained calls such as `cy.get("...").pause();`.

Closes #147 