### PR TITLE
fix: enable cypress/no-async-before

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ module.exports = {
     'no-assigning-return-values': require('./lib/rules/no-assigning-return-values'),
     'unsafe-to-chain-command': require('./lib/rules/unsafe-to-chain-command'),
     'no-unnecessary-waiting': require('./lib/rules/no-unnecessary-waiting'),
+    'no-async-before': require('./lib/rules/no-async-before'),
     'no-async-tests': require('./lib/rules/no-async-tests'),
     'assertion-before-screenshot': require('./lib/rules/assertion-before-screenshot'),
     'require-data-selectors': require('./lib/rules/require-data-selectors'),


### PR DESCRIPTION
- partially addresses issue https://github.com/cypress-io/eslint-plugin-cypress/issues/190

## Issue

- The rule [no-async-before](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-async-before.md) provided by PR https://github.com/cypress-io/eslint-plugin-cypress/pull/151 is not found when attempting to use it:

```text
  1:1  error  Definition for rule 'cypress/no-async-before' was not found  cypress/no-async-before
```

## Change

Added [no-async-before](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-async-before.md) to [index.js](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/index.js).
