### PR TITLE
chore: standardize meta.docs.description property

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,7 @@
         "pattern": "https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/{{name}}.md"
       }
     ],
+    "eslint-plugin/require-meta-docs-description": "error",
     "n/no-extraneous-require": [
       "error",
       {

--- a/lib/rules/assertion-before-screenshot.js
+++ b/lib/rules/assertion-before-screenshot.js
@@ -18,7 +18,7 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description: 'Assert on the page state before taking a screenshot, so the screenshot is consistent',
+      description: 'require screenshots to be preceded by an assertion',
       category: 'Possible Errors',
       recommended: false,
       url: 'https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/assertion-before-screenshot.md',

--- a/lib/rules/no-assigning-return-values.js
+++ b/lib/rules/no-assigning-return-values.js
@@ -19,7 +19,7 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description: 'Prevent assigning return values of cy calls',
+      description: 'disallow assigning return values of `cy` calls',
       category: 'Possible Errors',
       recommended: true,
       url: 'https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-assigning-return-values.md',

--- a/lib/rules/no-async-before.js
+++ b/lib/rules/no-async-before.js
@@ -4,7 +4,7 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description: 'Prevent using async/await in Cypress before methods',
+      description: 'disallow using `async`/`await` in Cypress `before` methods',
       category: 'Possible Errors',
       recommended: true,
       url: 'https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-async-before.md',

--- a/lib/rules/no-async-tests.js
+++ b/lib/rules/no-async-tests.js
@@ -4,7 +4,7 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description: 'Prevent using async/await in Cypress test cases',
+      description: 'disallow using `async`/`await` in Cypress test cases',
       category: 'Possible Errors',
       recommended: true,
       url: 'https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-async-tests.md',

--- a/lib/rules/no-force.js
+++ b/lib/rules/no-force.js
@@ -8,7 +8,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Disallow using of \'force: true\' option for click and type calls',
+      description: 'disallow using `force: true` with action commands',
       category: 'Possible Errors',
       recommended: false,
       url: 'https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-force.md',

--- a/lib/rules/no-pause.js
+++ b/lib/rules/no-pause.js
@@ -8,7 +8,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Disallow using of \'cy.pause\' calls',
+      description: 'disallow using `cy.pause()` calls',
       category: 'Possible Errors',
       recommended: false,
       url: 'https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-pause.md',

--- a/lib/rules/no-unnecessary-waiting.js
+++ b/lib/rules/no-unnecessary-waiting.js
@@ -4,7 +4,7 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description: 'Prevent waiting for arbitrary time periods',
+      description: 'disallow waiting for arbitrary time periods',
       category: 'Possible Errors',
       recommended: true,
       url: 'https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-unnecessary-waiting.md',

--- a/lib/rules/require-data-selectors.js
+++ b/lib/rules/require-data-selectors.js
@@ -4,7 +4,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Use data-* attributes to provide context to your selectors and insulate them from CSS or JS changes',
+      description: 'require `data-*` attribute selectors',
       category: 'Possible Errors',
       recommended: false,
       url: 'https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/require-data-selectors.md',

--- a/lib/rules/unsafe-to-chain-command.js
+++ b/lib/rules/unsafe-to-chain-command.js
@@ -3,7 +3,7 @@
 const { basename } = require('path')
 
 const NAME = basename(__dirname)
-const DESCRIPTION = 'Actions should be in the end of chains, not in the middle'
+const DESCRIPTION = 'disallow actions within chains'
 
 /**
  * Commands listed in the documentation with text: 'It is unsafe to chain further commands that rely on the subject after xxx.'


### PR DESCRIPTION
## Issue

The [eslint-plugin/require-meta-docs-description](https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/HEAD/docs/rules/require-meta-docs-description.md) rule of [eslint-plugin-eslint-plugin](https://www.npmjs.com/package/eslint-plugin-eslint-plugin) requires that the `meta.docs.description` property is properly populated. In particular it requires each rule to start with one of:

- enforce
- require
- disallow

None of the rule descriptions exactly meet this requirement.

| Rule                          | Current README description                                      | Current meta.docs.description                                                                       |
| :---------------------------- | :-------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
| `no-assigning-return-values`  | Prevent assigning return values of cy calls                     | Prevent assigning return values of `cy` calls                                                       |
| `no-unnecessary-waiting`      | Prevent waiting for arbitrary time periods                      | Prevent waiting for arbitrary time periods                                                          |
| `no-async-before`             | **missing**                                                     | Prevent using async/await in Cypress before methods                                                 |
| `no-async-tests`              | Prevent using async/await in Cypress test case                  | Prevent using async/await in Cypress test cases                                                     |
| `unsafe-to-chain-command`     | Prevent chaining from unsafe to chain commands                  | Actions should be in the end of chains, not in the middle                                           |
| `no-force`                    | Disallow using `force: true` with action commands               | Disallow using of \'force: true\' option for click and type calls                                   |
| `assertion-before-screenshot` | Ensure screenshots are preceded by an assertion                 | Assert on the page state before taking a screenshot, so the screenshot is consistent                |
| `require-data-selectors`      | Only allow data-\* attribute selectors (require-data-selectors) | Use data-* attributes to provide context to your selectors and insulate them from CSS or JS changes |
| `no-pause`                    | Disallow `cy.pause()` parent command                            | Disallow using of \'cy.pause\' calls                                                                |

Furthermore, if the npm module [eslint-doc-generator](https://github.com/bmish/eslint-doc-generator) from the ESLint team is used to auto-populate the list of rules in the [Rules](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/README.md#rules) section of the [README](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/README.md) file then the `meta.docs.description` of each rule needs to be more concise.

## Documentation reference

- [Rule Structure](https://eslint.org/docs/latest/extend/custom-rules#rule-structure) documentation

- [ESLint rules](https://eslint.org/docs/latest/rules/) for examples of rules which adhere to the required naming.

## Changes

### Config changes

Enable the rule [eslint-plugin/require-meta-docs-description](https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/HEAD/docs/rules/require-meta-docs-description.md) with the default option.

```json
  "rules": {
    ...
    "eslint-plugin/require-meta-docs-description": "error",
    ...
  }
```

### Content changes

| Rule                          | Current README description                                      | Current meta.docs.description                                                                         | Proposed meta.docs.description                             |
| :---------------------------- | :-------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| `assertion-before-screenshot` | Ensure screenshots are preceded by an assertion                 | Assert on the page state before taking a screenshot, so the screenshot is consistent                  | require screenshots to be preceded by an assertion         |
| `no-assigning-return-values`  | Prevent assigning return values of cy calls                     | Prevent assigning return values of cy calls                                                           | disallow assigning return values of cy calls               |
| `no-async-before`             | **missing**                                                     | Prevent using async/await in Cypress before methods                                                   | disallow using `async`/`await` in Cypress `before` methods |
| `no-async-tests`              | Prevent using async/await in Cypress test case                  | Prevent using async/await in Cypress test cases                                                       | disallow using `async`/`await` in Cypress test cases       |
| `no-force`                    | Disallow using `force: true` with action commands               | Disallow using of \'force: true\' option for click and type calls                                     | disallow using `force: true` with action commands          |
| `no-pause`                    | Disallow `cy.pause()` parent command                            | Disallow using of \'cy.pause\' calls                                                                  | disallow using `cy.pause()` calls                          |
| `no-unnecessary-waiting`      | Prevent waiting for arbitrary time periods                      | Prevent waiting for arbitrary time periods                                                            | disallow waiting for arbitrary time periods                |
| `require-data-selectors`      | Only allow data-\* attribute selectors (require-data-selectors) | Use `data-*` attributes to provide context to your selectors and insulate them from CSS or JS changes | require `data-*` attribute selectors                       |
| `unsafe-to-chain-command`     | Prevent chaining from unsafe to chain commands                  | Actions should be in the end of chains, not in the middle                                             | disallow actions within chains                             |
