### PR TITLE
docs: fix async further reading links

### DIFF
--- a/docs/rules/no-async-before.md
+++ b/docs/rules/no-async-before.md
@@ -1,6 +1,6 @@
 # Prevent using async/await in Cypress test cases (no-async-tests)
 
-Cypress commands that return a promise may cause side effects in before/beforeEach hooks, possibly causing unexpected behavior. 
+Cypress commands that return a promise may cause side effects in before/beforeEach hooks, possibly causing unexpected behavior.
 
 ## Rule Details
 
@@ -47,6 +47,5 @@ If there are genuine use-cases for using `async/await` in your before then you m
 
 ## Further Reading
 
-- [Commands Are Asynchronous](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress.html#Commands-Are-Asynchronous)
-- [Commands Are Promises](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress.html#Commands-Are-Promises)
-- [Commands Are Not Promises](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress.html#Commands-Are-Not-Promises)
+- [Mixing Async and Sync code](https://on.cypress.io/guides/core-concepts/introduction-to-cypress#Mixing-Async-and-Sync-code)
+- [Commands Are Asynchronous](https://on.cypress.io/guides/core-concepts/introduction-to-cypress.html#Commands-Are-Asynchronous)

--- a/docs/rules/no-async-tests.md
+++ b/docs/rules/no-async-tests.md
@@ -47,6 +47,5 @@ If there are genuine use-cases for using `async/await` in your test cases then y
 
 ## Further Reading
 
-- [Commands Are Asynchronous](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress.html#Commands-Are-Asynchronous)
-- [Commands Are Promises](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress.html#Commands-Are-Promises)
-- [Commands Are Not Promises](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress.html#Commands-Are-Not-Promises)
+- [Mixing Async and Sync code](https://on.cypress.io/guides/core-concepts/introduction-to-cypress#Mixing-Async-and-Sync-code)
+- [Commands Are Asynchronous](https://on.cypress.io/guides/core-concepts/introduction-to-cypress.html#Commands-Are-Asynchronous)


### PR DESCRIPTION
## Issue

The following rules documents contain outdated links concerning Promises:

- [no-async-before > Further Reading](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-async-before.md#further-reading)
- [no-async-tests > Further Reading](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-async-tests.md#further-reading)

The outdated links are:

- [Commands Are Promises](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress.html#Commands-Are-Promises)
    The target `https://docs.cypress.io/guides/core-concepts/introduction-to-cypress.html#Commands-Are-Promises` does not exist.
- [Commands Are Not Promises](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress.html#Commands-Are-Not-Promises)
    The target `https://docs.cypress.io/guides/core-concepts/introduction-to-cypress.html#Commands-Are-Not-Promises` does not exist.

## Changes

The Cypress documentation page https://docs.cypress.io/guides/core-concepts/introduction-to-cypress.html was changed by PR https://github.com/cypress-io/cypress-documentation/pull/4148 in Oct 2021. The PR text explains that the `Commands-Are-Promises` and `Commands-Are-Not-Promises` sections were replaced for clarity.

- Replace `Commands-Are-Promises` and `Commands-Are-Not-Promises` links using [The Cypress Command Queue](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress#The-Cypress-Command-Queue)
    https://on.cypress.io/guides/core-concepts/introduction-to-cypress#The-Cypress-Command-Queue
- Add [Mixing Async and Sync code](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress#Mixing-Async-and-Sync-code)
    https://on.cypress.io/guides/core-concepts/introduction-to-cypress#Mixing-Async-and-Sync-code

At the very bottom of [Mixing Async and Sync code](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress#Mixing-Async-and-Sync-code) there is a good explanation of the topic:

![async-await](https://github.com/cypress-io/eslint-plugin-cypress/assets/66998419/3adb7150-48cc-46de-82d7-da67a096dfa4)

