### PR TITLE
chore(deps): bump to ecmaVersion 2020

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,6 +35,6 @@
     "mocha/no-setup-in-describe": "off"
   },
   "parserOptions": {
-    "ecmaVersion": 2018
+    "ecmaVersion": 2020
   }
 }


### PR DESCRIPTION
## Issue

The instructions in the original ESLint blog post [Preparing your custom rules for ESLint v9.0.0](https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/) for converting the deprecated `context.getScope()` and `context.getAncestors()` did not work for ESLint `>=7 <=8.3.0`.

- I reported this in issue https://github.com/eslint/eslint.org/issues/559.

- The ESLint team responded with PR https://github.com/eslint/eslint.org/pull/560.

The new suggestions involve using the [Nullish coalescing operator (??)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing). The code falls back to previous API standards if the new API calls aren't available, so it can be used flexibly in old and new ESLint versions.

The new suggestions however fail linting in this repo with the following error message:

> error  Parsing error: Unexpected token ?

## Background

The [Nullish coalescing operator (??)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing) was introduced in ECMAScript 2020, the 11th edition (reference [ECMAScript 2025 > Introduction](https://tc39.es/ecma262/#sec-intro)).

ECMAScript 2020 (ES11) was released in June 2020.

The lowest supported version of Node.js is Release `18.x` [Node.js 18.0.0](https://nodejs.org/en/blog/release/v18.0.0) was released 2 years after ECMAScript 2020.

- The current setting was added recently by https://github.com/cypress-io/eslint-plugin-cypress/pull/177 using the setting `ecmaVersion` `2018` from https://github.com/cypress-io/cypress/blob/develop/npm/eslint-plugin-dev/lib/index.js#L210

## Change

Bump the `ecmaVersion` from `2018` to `2020`

https://github.com/cypress-io/eslint-plugin-cypress/blob/9222abb8ab0a103c9bd3cc7ade08a70b8d5bdabe/.eslintrc.json#L37-L39

## Related

- https://github.com/eslint/eslint.org/issues/559
- https://github.com/eslint/eslint.org/pull/560
- https://github.com/cypress-io/eslint-plugin-cypress/pull/182
