### PR TITLE
chore(deps): update husky to 9.0.11

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "eslint-plugin-eslint-plugin": "^6.0.0",
         "eslint-plugin-mocha": "^10.4.3",
         "eslint-plugin-n": "^17.2.1",
-        "husky": "^8.0.3",
+        "husky": "^9.0.11",
         "jest": "^29.7.0",
         "semantic-release": "19.0.3"
       },
@@ -4344,15 +4344,15 @@
       }
     },
     "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "version": "9.0.11",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
+      "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
       "dev": true,
       "bin": {
-        "husky": "lib/bin.js"
+        "husky": "bin.mjs"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
@@ -14530,9 +14530,9 @@
       "dev": true
     },
     "husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "version": "9.0.11",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
+      "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
       "dev": true
     },
     "ignore": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "eslint-plugin-eslint-plugin": "^6.0.0",
     "eslint-plugin-mocha": "^10.4.3",
     "eslint-plugin-n": "^17.2.1",
-    "husky": "^8.0.3",
+    "husky": "^9.0.11",
     "jest": "^29.7.0",
     "semantic-release": "19.0.3"
   },
@@ -40,6 +40,6 @@
     "start": "npm run test-watch",
     "test": "jest",
     "test-watch": "jest --watchAll",
-    "prepare": "husky install"
+    "prepare": "husky"
   }
 }


### PR DESCRIPTION
## Issue

- The repo is using [husky@8.0.3](https://github.com/typicode/husky/releases/tag/v8.0.3) which is not the recommended currently supported [Husky](https://typicode.github.io/husky/) `9.x` version. The current release is [husky@9.0.11](https://github.com/typicode/husky/releases/tag/v9.0.11).
- The release [Husky 9.x](https://github.com/typicode/husky/releases/tag/v9.0.1) dropped support for Node.js `14` and `16`, so PR #159 was restricted at the time to using Husky `8.x` because CircleCI was running on Node.js `16`.
- PR #171 updated the CircleCI workflow in this repo to use Node.js `v20.12.2` removing the restriction for Husky `9.x`.

## Changes

- Husky is updated to [husky@9.0.11](https://github.com/typicode/husky/releases/tag/v9.0.11) released on Feb 14, 2024.

### Detail steps

- The previous update in PR #159 updated Husky from [husky@3.0.0](https://github.com/typicode/husky/releases/tag/v3.0.0) released in Jul 2019 to [husky@8.0.3](https://github.com/typicode/husky/releases/tag/v8.0.3) released in Jan 2023.

- The steps to update from Husky `8.x` to Husky `9.x` are simpler and are described in the release notes for [husky@9.0.1](https://github.com/typicode/husky/releases/tag/v9.0.1)

1. Change `prepare` script from `husky install` to `husky` in [package.json](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/package.json)
2. Remove the initial three script lines from [.husky/pre-commit](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/.husky/pre-commit)

## Verification

Ubuntu `22.04.4` LTS, Node.js `v20.12.2` LTS

```shell
git clone https://github.com/cypress-io/eslint-plugin-cypress
cd eslint-plugin-cypress
npm ci
touch dummy.txt
git add .
git commit -m "commit dummy.txt"
```

Check that there are no warnings. The output should be similar to the following:

```text
$ git commit -m "commit dummy.txt"

> eslint-plugin-cypress@0.0.0-development lint
> eslint '*.js' '**/**/*.js'

[test/husky 14e9c96] commit dummy.txt
 1 file changed, 0 insertions(+), 0 deletions(-)
 create mode 100644 dummy.txt
```

## References

Documentation for this version is on https://github.com/typicode/husky/tree/v9.0.11/docs and https://typicode.github.io/husky/.
