### PR TITLE
docs: rule readme harmonization

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,18 +115,24 @@ For more, see the [ESLint rules](https://eslint.org/docs/user-guide/configuring/
 
 These rules enforce some of the [best practices recommended for using Cypress](https://on.cypress.io/best-practices).
 
-Rules with a check mark (✅) are enabled by default while using the `plugin:cypress/recommended` config.
+<!-- begin auto-generated rules list -->
 
-|     | Rule ID                                                                    | Description                                                     |
-| :-- | :------------------------------------------------------------------------- | :-------------------------------------------------------------- |
-| ✅  | [no-assigning-return-values](./docs/rules/no-assigning-return-values.md)   | Prevent assigning return values of cy calls                     |
-| ✅  | [no-unnecessary-waiting](./docs/rules/no-unnecessary-waiting.md)           | Prevent waiting for arbitrary time periods                      |
-| ✅  | [no-async-tests](./docs/rules/no-async-tests.md)                           | Prevent using async/await in Cypress test case                  |
-| ✅  | [unsafe-to-chain-command](./docs/rules/unsafe-to-chain-command.md)         | Prevent chaining from unsafe to chain commands                  |
-|     | [no-force](./docs/rules/no-force.md)                                       | Disallow using `force: true` with action commands               |
-|     | [assertion-before-screenshot](./docs/rules/assertion-before-screenshot.md) | Ensure screenshots are preceded by an assertion                 |
-|     | [require-data-selectors](./docs/rules/require-data-selectors.md)           | Only allow data-\* attribute selectors (require-data-selectors) |
-|     | [no-pause](./docs/rules/no-pause.md)           | Disallow `cy.pause()` parent command |
+💼 Configurations enabled in.\
+✅ Set in the `recommended` configuration.
+
+| Name                                                                     | Description                                                | 💼 |
+| :----------------------------------------------------------------------- | :--------------------------------------------------------- | :- |
+| [assertion-before-screenshot](docs/rules/assertion-before-screenshot.md) | require screenshots to be preceded by an assertion         |    |
+| [no-assigning-return-values](docs/rules/no-assigning-return-values.md)   | disallow assigning return values of `cy` calls             | ✅  |
+| [no-async-before](docs/rules/no-async-before.md)                         | disallow using `async`/`await` in Cypress `before` methods |    |
+| [no-async-tests](docs/rules/no-async-tests.md)                           | disallow using `async`/`await` in Cypress test cases       | ✅  |
+| [no-force](docs/rules/no-force.md)                                       | disallow using `force: true` with action commands          |    |
+| [no-pause](docs/rules/no-pause.md)                                       | disallow using `cy.pause()` calls                          |    |
+| [no-unnecessary-waiting](docs/rules/no-unnecessary-waiting.md)           | disallow waiting for arbitrary time periods                | ✅  |
+| [require-data-selectors](docs/rules/require-data-selectors.md)           | require `data-*` attribute selectors                       |    |
+| [unsafe-to-chain-command](docs/rules/unsafe-to-chain-command.md)         | disallow actions within chains                             | ✅  |
+
+<!-- end auto-generated rules list -->
 
 ## Mocha and Chai
 


### PR DESCRIPTION
- supports resolution of issue #193

## Issues

This PR deals with the [README > Rules](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/README.md#rules) section.

1. The rule descriptions do not agree with the [lib/rules](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/lib/rules) property `meta.docs.description`.
2. The rules are only sorted according to inclusion in the recommended set. Otherwise there is no recognizable sorting order.
3. The entry for [no-async-before](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-async-before.md) is missing (part of issue #193)

## Changes

1. The rule table is formatted and populated according to the standard derived from the [eslint-doc-generator](https://www.npmjs.com/package/eslint-doc-generator)
2. The rule descriptions are a direct copy of the `meta.docs.description` property from the corresponding [lib/rules](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/lib/rules) source.
3. Entries for all 9 rules are listed.
4. The rules are sorted alphabetically.
5. The [README > Rules](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/README.md#rules) section is prepared for auto-generated content.

**AFTER**

![image](https://github.com/cypress-io/eslint-plugin-cypress/assets/66998419/3738faeb-a5b0-4635-a1e6-31bdad193c98)
