### PR TITLE
docs: rule documentation harmonization

### DIFF
--- a/docs/rules/assertion-before-screenshot.md
+++ b/docs/rules/assertion-before-screenshot.md
@@ -1,19 +1,22 @@
-## Assertion Before Screenshot
+# Require screenshots to be preceded by an assertion (`cypress/assertion-before-screenshot`)
 
+<!-- end auto-generated rule header -->
 If you take screenshots without assertions then you may get different screenshots depending on timing.
 
 For example, if clicking a button makes some network calls and upon success, renders something, then the screenshot may sometimes have the new render and sometimes not.
 
+## Rule Details
+
 This rule checks there is an assertion making sure your application state is correct before doing a screenshot. This makes sure the result of the screenshot will be consistent.
 
-Invalid:
+Examples of **incorrect** code for this rule:
 
 ```js
 cy.visit('myUrl');
 cy.screenshot();
 ```
 
-Valid:
+Examples of **correct** code for this rule:
 
 ```js
 cy.visit('myUrl');

--- a/docs/rules/no-assigning-return-values.md
+++ b/docs/rules/no-assigning-return-values.md
@@ -1,3 +1,8 @@
-## No Assigning Return Values
+# Disallow assigning return values of `cy` calls (`cypress/no-assigning-return-values`)
+
+💼 This rule is enabled in the ✅ `recommended` config.
+
+<!-- end auto-generated rule header -->
+## Further Reading
 
 See [the Cypress Best Practices guide](https://on.cypress.io/best-practices#Assigning-Return-Values).

--- a/docs/rules/no-async-before.md
+++ b/docs/rules/no-async-before.md
@@ -1,6 +1,7 @@
-# Prevent using async/await in Cypress test cases (no-async-tests)
+# Disallow using `async`/`await` in Cypress `before` methods (`cypress/no-async-before`)
 
-Cypress commands that return a promise may cause side effects in before/beforeEach hooks, possibly causing unexpected behavior.
+<!-- end auto-generated rule header -->
+Cypress commands that return a promise may cause side effects in `before`/`beforeEach` hooks, possibly causing unexpected behavior.
 
 ## Rule Details
 
@@ -38,12 +39,11 @@ describe('my feature', () => {
     // other operations
   })
 })
-
 ```
 
 ## When Not To Use It
 
-If there are genuine use-cases for using `async/await` in your before then you may not want to include this rule (or at least demote it to a warning).
+If there are genuine use-cases for using `async/await` in your `before` hooks then you may not want to include this rule (or at least demote it to a warning).
 
 ## Further Reading
 

--- a/docs/rules/no-async-tests.md
+++ b/docs/rules/no-async-tests.md
@@ -1,6 +1,10 @@
-# Prevent using async/await in Cypress test cases (no-async-tests)
+# Disallow using `async`/`await` in Cypress test cases (`cypress/no-async-tests`)
 
-Cypress tests [that return a promise will error](https://docs.cypress.io/guides/references/error-messages.html#Cypress-detected-that-you-returned-a-promise-from-a-command-while-also-invoking-one-or-more-cy-commands-in-that-promise) and cannot run successfully. An `async` function returns a promise under the hood, so a test using an `async` function will also error.
+💼 This rule is enabled in the ✅ `recommended` config.
+
+<!-- end auto-generated rule header -->
+Cypress tests [that return a promise will error](https://docs.cypress.io/guides/references/error-messages.html#Cypress-detected-that-you-returned-a-promise-from-a-command-while-also-invoking-one-or-more-cy-commands-in-that-promise) and cannot run successfully.
+An `async` function returns a promise under the hood, so a test using an `async` function will also error.
 
 ## Rule Details
 
@@ -38,7 +42,6 @@ describe('my feature', () => {
     // other operations
   })
 })
-
 ```
 
 ## When Not To Use It

--- a/docs/rules/no-force.md
+++ b/docs/rules/no-force.md
@@ -1,5 +1,6 @@
-# disallow using of 'force: true' option (no-force)
+# Disallow using `force: true` with action commands (`cypress/no-force`)
 
+<!-- end auto-generated rule header -->
 Using `force: true` on inputs appears to be confusing rather than helpful.
 It usually silences the actual problem instead of providing a way to overcome it.
 See [Cypress Core Concepts](https://docs.cypress.io/guides/core-concepts/interacting-with-elements.html#Forcing).
@@ -8,15 +9,15 @@ If enabling this rule, it's recommended to set the severity to `warn`.
 
 ## Rule Details
 
-This rule aims to disallow using of the `force` option on:[`.click()`](https://on.cypress.io/click),
+This rule disallows using the `force` option on:[`.click()`](https://on.cypress.io/click),
 [`.dblclick()`](https://on.cypress.io/dblclick), [`.type()`](https://on.cypress.io/type),
 [`.rightclick()`](https://on.cypress.io/rightclick), [`.select()`](https://on.cypress.io/select),
 [`.focus()`](https://on.cypress.io/focus), [`.check()`](https://on.cypress.io/check),
 and [`.trigger()`](https://on.cypress.io/trigger).
+
 Examples of **incorrect** code for this rule:
 
 ```js
-
 cy.get('button').click({force: true})
 cy.get('button').dblclick({force: true})
 cy.get('input').type('somth', {force: true})
@@ -26,13 +27,11 @@ cy.get('input').rightclick({force: true})
 cy.get('input').check({force: true})
 cy.get('input').select({force: true})
 cy.get('input').focus({force: true})
-
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
-
 cy.get('button').click()
 cy.get('button').click({multiple: true})
 cy.get('button').dblclick()
@@ -42,9 +41,7 @@ cy.get('input').rightclick({anyoption: true})
 cy.get('input').check()
 cy.get('input').select()
 cy.get('input').focus()
-
 ```
-
 
 ## When Not To Use It
 

--- a/docs/rules/no-pause.md
+++ b/docs/rules/no-pause.md
@@ -1,14 +1,17 @@
-## Do not use `cy.pause` command
+# Disallow using `cy.pause()` calls (`cypress/no-pause`)
 
-It is recommended to remove [cy.pause](https://on.cypress.io/pause) command before committing the specs to avoid other developers getting unexpected results.
+<!-- end auto-generated rule header -->
+It is recommended to remove any [cy.pause](https://on.cypress.io/pause) commands before committing specs to avoid other developers getting unexpected results.
 
-Invalid:
+## Rule Details
+
+Examples of **incorrect** code for this rule:
 
 ```js
 cy.pause();
 ```
 
-Valid:
+Examples of **correct** code for this rule:
 
 ```js
 // only the parent cy.pause command is detected

--- a/docs/rules/no-unnecessary-waiting.md
+++ b/docs/rules/no-unnecessary-waiting.md
@@ -1,3 +1,8 @@
-## No Unnecessary Waiting
+# Disallow waiting for arbitrary time periods (`cypress/no-unnecessary-waiting`)
+
+💼 This rule is enabled in the ✅ `recommended` config.
+
+<!-- end auto-generated rule header -->
+## Further Reading
 
 See [the Cypress Best Practices guide](https://on.cypress.io/best-practices#Unnecessary-Waiting).

--- a/docs/rules/require-data-selectors.md
+++ b/docs/rules/require-data-selectors.md
@@ -1,13 +1,14 @@
-## Only allow `data-*` attribute selectors (require-data-selectors)
-only allow `cy.get` to allow selectors that target `data-*` attributes
+# Require `data-*` attribute selectors (`cypress/require-data-selectors`)
 
-See [the Cypress Best Practices guide](https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements).
+<!-- end auto-generated rule header -->
+Require `cy.get` to use only selectors that target `data-*` attributes.
 
 > Note: If you use this rule, consider only using the `warn` error level, since using `data-*` attribute selectors may not always be possible.
 
-### Rule Details
+## Rule Details
 
-examples of **incorrect** code with `require-data-selectors`:
+Examples of **incorrect** code for this rule:
+
 ```js
 cy.get(".a")
 cy.get('[daedta-cy=submit]').click()
@@ -16,8 +17,13 @@ cy.get(".btn-large").click()
 cy.get(".btn-.large").click()
 ```
 
-examples of **correct** code with `require-data-selectors`:
+Examples of **correct** code for this rule:
+
 ```js
 cy.get('[data-cy=submit]').click()
 cy.get('[data-QA=submit]')
 ```
+
+## Further Reading
+
+See [the Cypress Best Practices guide](https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements).

--- a/docs/rules/unsafe-to-chain-command.md
+++ b/docs/rules/unsafe-to-chain-command.md
@@ -1,3 +1,18 @@
-## Unsafe to chain command
+# Disallow actions within chains (`cypress/unsafe-to-chain-command`)
+
+💼 This rule is enabled in the ✅ `recommended` config.
+
+<!-- end auto-generated rule header -->
+### Options
+
+<!-- begin auto-generated rule options list -->
+
+| Name      | Description                                                 | Type  | Default |
+| :-------- | :---------------------------------------------------------- | :---- | :------ |
+| `methods` | An additional list of methods to check for unsafe chaining. | Array | `[]`    |
+
+<!-- end auto-generated rule options list -->
+
+## Further Reading
 
 See [retry-ability guide](https://docs.cypress.io/guides/core-concepts/retry-ability#Actions-should-be-at-the-end-of-chains-not-the-middle).


### PR DESCRIPTION
- supports resolution of issue #193

## Issues

This PR deals with issues in the set of 9 [docs/rules](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/docs/rules) Markdown files.

1. The top-level headers of the `docs/rules` documents do not agree with the [lib/rules](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/lib/rules) property `meta.docs.description`.
2. Some headers do not include the name of the rule.
3. Formatting of the `docs/rules` documents is inconsistent.

## Changes

1. Top-level headers of the `docs/rules` documents are built using the `meta.docs.description` property from the corresponding [lib/rules](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/lib/rules) source.
2. The `docs/rules` top-level header has the name of the rule in the form `(cypress/<rule-name>)` consistently appended.
3. Lower level headings and content are aligned with the Yeoman-based ESLint generator [eslint/generator-eslint](https://github.com/eslint/generator-eslint) template [_doc.md](https://github.com/eslint/generator-eslint/blob/main/rule/templates/_doc.md) as follows:

```text
- Rule Details
  - Options
- When Not To Use It
- Further Reading
```

4. Other grammatical text changes are made.
5. The documents are prepared for auto-generated content

## Comments

- This PR only aims to restructure existing information.

- There is scope for further improvement of rule documents by adding content. For instance, the [docs/rules/no-unnecessary-waiting.md](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-unnecessary-waiting.md) essentially contains only a link to the Cypress documentation site without providing any other description or summary. This could optionally be covered in a later PR.

- Due to issues with the document generator incorrectly duplicating headers in some situations, the planned PR to add the npm module [eslint-doc-generator](https://www.npmjs.com/package/eslint-doc-generator) is held back for the time being. The issues have been reported and PR https://github.com/bmish/eslint-doc-generator/pull/524 plans to address.
