### PR TITLE
refactor: convert config .eslintrc.json to .js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
   "env": {
     "node": true,
     "es6": true
@@ -15,21 +15,11 @@
     "plugin:mocha/recommended"
   ],
   "rules": {
-    "eslint-plugin/require-meta-docs-url": [
-      "error",
-      {
-        "pattern": "https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/{{name}}.md"
-      }
-    ],
+    "eslint-plugin/require-meta-docs-url":
+      ["error", { "pattern": "https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/{{name}}.md" }],
     "eslint-plugin/require-meta-docs-description": "error",
-    "n/no-extraneous-require": [
-      "error",
-      {
-        "allowModules": [
-          "jest-config"
-        ]
-      }
-    ],
+    "n/no-extraneous-require":
+      ["error", { "allowModules": ["jest-config"] }],
     "no-redeclare": "off",
     "mocha/no-mocha-arrows": "off",
     "mocha/no-setup-in-describe": "off"


### PR DESCRIPTION
## Issue

[ESLint 8.x configuration files](https://eslint.org/docs/v8.x/use/configure/configuration-files) in JSON format become [deprecated in ESLint 9.x](https://eslint.org/docs/latest/use/configure/configuration-files-deprecated) which only uses JavaScript format.

## Change

The [.eslintrc.json](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/.eslintrc.json) ESLint configuration file is converted to `.eslintrc.js` (JavaScript). (Note that this does not convert to a "flat config" format, which is left for a later migration stage.)

This is one building block contributing to a migration from ESLint `8.x` to ESLint `9.x`.

## Verification

On Ubuntu `22.04.4` LTS, Node.js `20.12.2` LTS

```shell
npm ci
npm run lint
```

## References

### ESLint 8.x

- [ESLint 8.x configuration files](https://eslint.org/docs/v8.x/use/configure/configuration-files)
- [ESLint 8.x configuration files (new)](https://eslint.org/docs/v8.x/use/configure/configuration-files-new)

### ESLint 9.x

- [ESLint 9.x configuration files](https://eslint.org/docs/latest/use/configure/configuration-files)
- [ESLint 9.x configuration files (deprecated)](https://eslint.org/docs/latest/use/configure/configuration-files-deprecated)