### PR TITLE
docs: add document for FlatCompat use

### DIFF
--- a/FLAT-CONFIG.md
+++ b/FLAT-CONFIG.md
@@ -1,0 +1,132 @@
+# Cypress ESLint Plugin - Flat Config
+
+This document supplements the [README](README.md) document and describes how to use the Cypress ESLint Plugin (`eslint-plugin-cypress`) in an ESLint flat config environment.
+
+Usage with ESLint `8.57.0` is described. An update to this document is planned to cover ESLint `9.x` additionally.
+
+## Introduction
+
+[ESLint v9.0.0](https://eslint.org/blog/2024/04/eslint-v9.0.0-released/) was released on April 5, 2024, establishing flat config as the default for this version.
+
+Previously, ESLint had announced in their blog post [Flat config rollout plans](https://eslint.org/blog/2023/10/flat-config-rollout-plans/) in October 2023 that flat config was planned to be the default in ESLint `v9.0.0` and that the eslintrc configuration system is planned to be removed in the future ESLint `v10.0.0`.
+
+The Cypress ESLint Plugin (`eslint-plugin-cypress`) is currently based on ESLint `8.x` and has not yet been migrated to support Flat Config natively. [ESLint's new config system, Part 2: Introduction to flat config](https://eslint.org/blog/2022/08/new-config-system-part-2/) from August 2022 introduced the [Backwards compatibility utility](https://eslint.org/blog/2022/08/new-config-system-part-2/#backwards-compatibility-utility). This gives the capability to use `eslint-plugin-cypress` in an ESLint flat config environment.
+
+The following information details installation and usage examples for `eslint-plugin-cypress` together with related plugins in such an ESLint `8.57.0` flat config environment.
+
+## Installation
+
+It is recommended to use a minimum ESLint `v8.x` version [eslint@8.57.0](https://github.com/eslint/eslint/releases/tag/v8.57.0).
+
+```shell
+npm install eslint@^8.57.0 @eslint/eslintrc eslint-plugin-cypress --save-dev
+```
+
+or
+
+```shell
+yarn add eslint@^8.57.0 @eslint/eslintrc eslint-plugin-cypress --dev
+```
+
+## Usage examples
+
+Add a flat configuration file `eslint.config.mjs` file to the root directory of your Cypress project. In the following sections, different examples of possible configuration file contents are given, together with some brief explanations. Adapt these examples according to your needs.
+
+### Cypress
+
+All rules from `eslint-plugin-cypress` are available through the `FlatCompat` class of [@eslint/eslintrc](https://www.npmjs.com/package/@eslint/eslintrc).
+- [cypress/unsafe-to-chain-command](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/unsafe-to-chain-command.md) is active and set to `error`
+
+```js
+import { FlatCompat } from '@eslint/eslintrc'
+const compat = new FlatCompat()
+export default [
+  ...compat.config(
+    {
+      plugins: ['cypress'],
+      rules: {
+        'cypress/unsafe-to-chain-command': 'error'
+      }
+    })
+]
+```
+
+### Cypress recommended
+
+The `eslint-plugin-cypress` [recommended rules](README.md#rules) `plugin:cypress/recommended` are activated, except for
+- [cypress/no-unnecessary-waiting](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-unnecessary-waiting.md) set to `off`
+
+```js
+import { FlatCompat } from '@eslint/eslintrc'
+const compat = new FlatCompat()
+export default [
+  ...compat.config(
+    {
+      extends: ['plugin:cypress/recommended'],
+      rules: {
+        'cypress/no-unnecessary-waiting': 'off'
+      }
+    })
+]
+```
+
+### Cypress and Mocha recommended
+
+[eslint-plugin-mocha](https://www.npmjs.com/package/eslint-plugin-mocha) is added to the previous example. This plugin offers a flat file recommended option `configs.flat.recommended`.
+
+The settings for individual `mocha` rules from the `configs.flat.recommended` option are changed.
+- [mocha/no-exclusive-tests](https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/docs/rules/no-exclusive-tests.md) and [mocha/no-skipped-tests](https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/docs/rules/no-skipped-tests.md) are set to `error` instead of `warn`
+- [mocha/no-mocha-arrows](https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/docs/rules/no-mocha-arrows.md) is set to `off` instead of `error`
+
+```shell
+npm install eslint-plugin-mocha@^10.4.3 --save-dev
+```
+
+```js
+import { FlatCompat } from '@eslint/eslintrc'
+import mochaPlugin from 'eslint-plugin-mocha'
+const compat = new FlatCompat()
+export default [
+  mochaPlugin.configs.flat.recommended, {
+    rules: {
+      'mocha/no-exclusive-tests': 'error',
+      'mocha/no-skipped-tests': 'error',
+      'mocha/no-mocha-arrows': 'off'
+    }
+  },
+  ...compat.config(
+    {
+      extends: ['plugin:cypress/recommended'],
+      rules: {
+        'cypress/no-unnecessary-waiting': 'off'
+      }
+    })
+]
+```
+
+### Cypress and Chai recommended
+
+[eslint-plugin-chai-friendly](https://www.npmjs.com/package/eslint-plugin-chai-friendly) is combined with the Cypress plugin `eslint-plugin-cypress`.
+
+The [eslint-plugin-chai-friendly](https://www.npmjs.com/package/eslint-plugin-chai-friendly) plugin does not currently offer flat config options and so the `FlatCompat` class of [@eslint/eslintrc](https://www.npmjs.com/package/@eslint/eslintrc) enables this plugin to be used too. The recommended rules for both plugins are used: `plugin:cypress/recommended` and `plugin:chai-friendly/recommended`.
+
+```shell
+npm install eslint-plugin-chai-friendly --save-dev
+```
+
+```js
+import { FlatCompat } from '@eslint/eslintrc'
+const compat = new FlatCompat()
+export default [
+  ...compat.config(
+    {
+      extends: [
+        'plugin:cypress/recommended',
+        'plugin:chai-friendly/recommended'
+      ],
+      rules: {
+        'cypress/no-unnecessary-waiting': 'off',
+      }
+    })
+]
+```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ yarn add eslint-plugin-cypress --dev
 
 ## Usage
 
-Add an `.eslintrc.json` file to your `cypress` directory with the following:
+If you are using ESLint `v7` or `v8`, then add an `.eslintrc.json` file to the root directory of your Cypress project with the contents shown below.
+
+Optionally, if you are using ESLint `v8` with a minimum version of `8.57.0`, you can use the [new configuration file](https://eslint.org/docs/v8.x/use/configure/configuration-files-new) format with filename `eslint.config.*js`. In this case, please refer to [additional Flat config installation and configuration details](FLAT-CONFIG.md).
 
 ```json
 {


### PR DESCRIPTION
- relates to issue #146

## Issue

The [README > Usage](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/README.md#usage) section describes how to add an `.eslintrc.json` configuration file to use the `eslint-plugin-cypress` plugin. With the announcement and release of [ESLint v9](https://eslint.org/blog/2024/04/eslint-v9.0.0-released/) on Apr 5, 2024, configuration files in the format `.eslintrc.*` have become deprecated (see [ESLint 8.x Configuration Files](https://eslint.org/docs/v8.x/use/configure/configuration-files)).

The plugin needs to document how to set up and use non-deprecated [Configuration Files (New)](https://eslint.org/docs/v8.x/use/configure/configuration-files-new) for ESLint `v8`. These are JavaScript files using an `eslint.config.*js` naming convention. Users of the plugin may otherwise be blocked from preparing to update to ESLint `v9` through lack of information.

## Constraints

### Plugins

- `eslint-plugin-cypress` has not yet implemented the instructions in [Plugin Migration to Flat Config](https://eslint.org/docs/latest/extend/plugin-migration-flat-config) (see issue https://github.com/cypress-io/eslint-plugin-cypress/issues/146). It is compatible with ESLint `v7` and `v8`.
- [eslint-plugin-mocha](https://www.npmjs.com/package/eslint-plugin-mocha) documents how to `import` a flat config. It is compatible with ESLint `v7` to `v9`.
- [eslint-plugin-chai-friendly](https://www.npmjs.com/package/eslint-plugin-chai-friendly) documents only how to use an `.eslintrc.*` legacy config file. The latest version [eslint-plugin-chai-friendly@0.7.4](https://github.com/ihordiachenko/eslint-plugin-chai-friendly/releases/tag/v0.7.4) is not compatible with the ESLint `v9` API due to usage of `context.getAncestors`. It is compatible with ESLint `v3` to `v8`.

### Node.js

- The [package.json](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/package.json) of `eslint-plugin-cypress` has no package [type](https://nodejs.org/docs/latest/api/packages.html#type) defined and so it defaults to [CommonJS](https://nodejs.org/docs/latest/api/modules.html).
- `import` statements are supported only in [ECMAScript (ES module / ESM)](https://nodejs.org/docs/latest/api/esm.html).
- The default [type](https://nodejs.org/docs/latest/api/packages.html#type) of [CommonJS](https://nodejs.org/docs/latest/api/modules.html) constrains to using the `.mjs` extension for the ESLint configuration file in order to use `import` statements.

### ESLint usage

- The ESLint [Backwards compatibility utility](https://eslint.org/blog/2022/08/new-config-system-part-2/#backwards-compatibility-utility), with the `FlatCompat` class from the npm module [@eslint/eslintrc](https://www.npmjs.com/package/@eslint/eslintrc), is required to use legacy plugins in a flat config environment.
- [eslint@8.57.0](https://github.com/eslint/eslint/releases/tag/v8.57.0) is the minimum version to detect and use an `eslint.config.mjs` configuration file (see [ESLint CHANGELOG](https://github.com/eslint/eslint/blob/main/CHANGELOG.md) and [ESLint 8.x > Configuration File Resolution](https://eslint.org/docs/v8.x/use/configure/configuration-files-new#configuration-file-resolution)).

## Change

In order to provide clear, readable instructions for both legacy (`.eslintrc.*`) and new, flat config (`eslint.config.*js`) users, a separate document `FLAT-CONFIG.md` is created for the new flat config instructions.

## Future steps

- Building on this documentation change, include support for usage of the `eslint-plugin-cypress` plugin in `FlatCompat` compatibility mode together with ESLint `v9` in addition to ESLint `8.57.0`.

## References

- [Configuration Migration Guide](https://eslint.org/docs/latest/use/configure/migration-guide)
- [Backwards compatibility utility](https://eslint.org/blog/2022/08/new-config-system-part-2/#backwards-compatibility-utility)
- npm module [@eslint/eslintrc](https://www.npmjs.com/package/@eslint/eslintrc)

### ESLint 8.x

- [ESLint 8.x Configuration Files](https://eslint.org/docs/v8.x/use/configure/configuration-files)
- [ESLint 8.x Configuration Files (New)](https://eslint.org/docs/v8.x/use/configure/configuration-files-new)
- [ESLint 8.x Configuration Files (New) > Configuration File Resolution](https://eslint.org/docs/v8.x/use/configure/configuration-files-new#configuration-file-resolution)
