### PR TITLE
feat: support eslint v9 through @eslint/eslintrc

### DIFF
--- a/FLAT-CONFIG.md
+++ b/FLAT-CONFIG.md
@@ -2,7 +2,7 @@
 
 This document supplements the [README](README.md) document and describes how to use the Cypress ESLint Plugin (`eslint-plugin-cypress`) in an ESLint flat config environment.
 
-Usage with ESLint `8.57.0` is described. An update to this document is planned to cover ESLint `9.x` additionally.
+Usage with ESLint `8.57.0` and ESLint `9.x` is described.
 
 ## Introduction
 
@@ -12,20 +12,20 @@ Previously, ESLint had announced in their blog post [Flat config rollout plans](
 
 The Cypress ESLint Plugin (`eslint-plugin-cypress`) is currently based on ESLint `8.x` and has not yet been migrated to support Flat Config natively. [ESLint's new config system, Part 2: Introduction to flat config](https://eslint.org/blog/2022/08/new-config-system-part-2/) from August 2022 introduced the [Backwards compatibility utility](https://eslint.org/blog/2022/08/new-config-system-part-2/#backwards-compatibility-utility). This gives the capability to use `eslint-plugin-cypress` in an ESLint flat config environment.
 
-The following information details installation and usage examples for `eslint-plugin-cypress` together with related plugins in such an ESLint `8.57.0` flat config environment.
+The following information details installation and usage examples for `eslint-plugin-cypress` together with related plugins in an ESLint flat config environment.
 
 ## Installation
 
-It is recommended to use a minimum ESLint `v8.x` version [eslint@8.57.0](https://github.com/eslint/eslint/releases/tag/v8.57.0).
+It is recommended to use a minimum ESLint `8.x` version [eslint@8.57.0](https://github.com/eslint/eslint/releases/tag/v8.57.0) or ESLint `9.x`.
 
 ```shell
-npm install eslint@^8.57.0 @eslint/eslintrc eslint-plugin-cypress --save-dev
+npm install eslint @eslint/eslintrc eslint-plugin-cypress@^3.1.1 --save-dev
 ```
 
 or
 
 ```shell
-yarn add eslint@^8.57.0 @eslint/eslintrc eslint-plugin-cypress --dev
+yarn add eslint @eslint/eslintrc eslint-plugin-cypress@^3.1.1 --dev
 ```
 
 ## Usage examples
@@ -130,3 +130,5 @@ export default [
     })
 ]
 ```
+
+**Pending the resolution of issue https://github.com/ihordiachenko/eslint-plugin-chai-friendly/issues/32 [eslint-plugin-chai-friendly](https://www.npmjs.com/package/eslint-plugin-chai-friendly) cannot be used with ESLint `v9`.**

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Note: If you installed ESLint globally then you must also install `eslint-plugin
 
 ## Installation
 
-Prerequisites: [ESLint](https://www.npmjs.com/package/eslint) `v7` or `v8`. ESLint `v9` is **not** supported yet.
+Prerequisites: [ESLint](https://www.npmjs.com/package/eslint) `v7`, `v8` or `v9`.
+This plugin supports the use of [Flat config files](https://eslint.org/docs/latest/use/configure/configuration-files) with ESLint `8.57.0` and above through [@eslint/eslintrc](https://www.npmjs.com/package/@eslint/eslintrc).
 
 ```sh
 npm install eslint-plugin-cypress --save-dev
@@ -18,9 +19,9 @@ yarn add eslint-plugin-cypress --dev
 
 ## Usage
 
-If you are using ESLint `v7` or `v8`, then add an `.eslintrc.json` file to the root directory of your Cypress project with the contents shown below.
+If you are using ESLint `v7` or `v8`, then add an `.eslintrc.json` file to the root directory of your Cypress project with the contents shown below. You can continue to use this format with ESLint `v9` if you set the `ESLINT_USE_FLAT_CONFIG` environment variable to `false` (see [ESLint v9 > Configuration Files (Deprecated)](https://eslint.org/docs/latest/use/configure/configuration-files-deprecated).
 
-Optionally, if you are using ESLint `v8` with a minimum version of `8.57.0`, you can use the [new configuration file](https://eslint.org/docs/v8.x/use/configure/configuration-files-new) format with filename `eslint.config.*js`. In this case, please refer to [additional Flat config installation and configuration details](FLAT-CONFIG.md).
+ESLint `v9` uses a [Flat config file](https://eslint.org/docs/latest/use/configure/configuration-files) format with filename `eslint.config.*js` by default. Please refer to [additional Flat config installation and configuration details](FLAT-CONFIG.md). (You may also use this with ESLint `8.57.0`.)
 
 ```json
 {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "semantic-release": "23.0.8"
       },
       "peerDependencies": {
-        "eslint": ">=7 <9"
+        "eslint": ">=7"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/cypress-io/eslint-plugin-cypress#readme",
   "peerDependencies": {
-    "eslint": ">=7 <9"
+    "eslint": ">=7"
   },
   "dependencies": {
     "globals": "^13.20.0"


### PR DESCRIPTION
**This PR releases the plugin for use on ESLint `9.x` in addition to `7.x` and `8.x`**
**It provides also a minimal documentation update necessary to support this addition**

## Issue

The [eslint-plugin-cypress@3.0.0](https://github.com/cypress-io/eslint-plugin-cypress/releases/tag/v3.0.0) release was blocked from installing on `eslint >= 9` through `peerDependencies`

https://github.com/cypress-io/eslint-plugin-cypress/blob/dc22026dae65c71c338605301a878d3c4caf0174/package.json#L21-L23

## Related resolutions

- An API compatibility issue with ESLint `v9` was resolved in the [eslint-plugin-cypress@3.0.2](https://github.com/cypress-io/eslint-plugin-cypress/releases/tag/v3.0.2) release
- PR https://github.com/cypress-io/eslint-plugin-cypress/pull/201 added documentation to describe how to use the plugin with a Flat config, which is the default for ESLint `v9`.

## Change

- `peerDependencies` are relaxed to allow installation on any version starting with `eslint@7` and including `eslint@9`.
- The [README](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/README.md) and [FLAT-CONFIG](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/FLAT-CONFG.md) documents are updated to cover use of the plugin on all supported versions: `v7`, `v8` and `v9`

| ESLint version | legacy `.eslintrc.*` | flat config `eslint.config.*js` |
| -------------- | -------------------- | ------------------------------- |
| v7             | supported            | not available                   |
| v8             | supported            | supported (1)                   |
| v9             | supported (2)        | supported (1)                   |

(1) Supported through the `FlatCompat` class of [@eslint/eslintrc](https://www.npmjs.com/package/@eslint/eslintrc)
(2) Deprecated by ESLint `v9`. Can be used with environment variable `ESLINT_USE_FLAT_CONFIG` set to `false`
