### PR TITLE
tests: migrate to FlatRuleTester v8

### DIFF
--- a/tests/lib/rules/assertion-before-screenshot.js
+++ b/tests/lib/rules/assertion-before-screenshot.js
@@ -1,35 +1,35 @@
 'use strict'
 
 const rule = require('../../../lib/rules/assertion-before-screenshot')
-const RuleTester = require('eslint').RuleTester
+const { FlatRuleTester } = require('eslint/use-at-your-own-risk')
 
-const ruleTester = new RuleTester()
+const ruleTester = new FlatRuleTester()
 
 const errors = [{ messageId: 'unexpected' }]
-const parserOptions = { ecmaVersion: 6 }
+const languageOptions = { ecmaVersion: 6 }
 
 ruleTester.run('assertion-before-screenshot', rule, {
   valid: [
-    { code: 'cy.get(".some-element"); cy.screenshot();', parserOptions },
-    { code: 'cy.get(".some-element").should("exist").screenshot();', parserOptions },
-    { code: 'cy.get(".some-element").should("exist").screenshot().click()', parserOptions, errors },
-    { code: 'cy.get(".some-element").should("exist"); if(true) cy.screenshot();', parserOptions },
-    { code: 'if(true) { cy.get(".some-element").should("exist"); cy.screenshot(); }', parserOptions },
-    { code: 'cy.get(".some-element").should("exist"); if(true) { cy.screenshot(); }', parserOptions },
-    { code: 'const a = () => { cy.get(".some-element").should("exist"); cy.screenshot(); }', parserOptions, errors },
-    { code: 'cy.get(".some-element").should("exist").and("be.visible"); cy.screenshot();', parserOptions },
-    { code: 'cy.get(".some-element").contains("Text"); cy.screenshot();', parserOptions },
+    { code: 'cy.get(".some-element"); cy.screenshot();', languageOptions },
+    { code: 'cy.get(".some-element").should("exist").screenshot();', languageOptions },
+    { code: 'cy.get(".some-element").should("exist").screenshot().click()', languageOptions, errors },
+    { code: 'cy.get(".some-element").should("exist"); if(true) cy.screenshot();', languageOptions },
+    { code: 'if(true) { cy.get(".some-element").should("exist"); cy.screenshot(); }', languageOptions },
+    { code: 'cy.get(".some-element").should("exist"); if(true) { cy.screenshot(); }', languageOptions },
+    { code: 'const a = () => { cy.get(".some-element").should("exist"); cy.screenshot(); }', languageOptions, errors },
+    { code: 'cy.get(".some-element").should("exist").and("be.visible"); cy.screenshot();', languageOptions },
+    { code: 'cy.get(".some-element").contains("Text"); cy.screenshot();', languageOptions },
   ],
 
   invalid: [
-    { code: 'cy.screenshot()', parserOptions, errors },
-    { code: 'cy.visit("somepage"); cy.screenshot();', parserOptions, errors },
-    { code: 'cy.custom(); cy.screenshot()', parserOptions, errors },
-    { code: 'cy.get(".some-element").click(); cy.screenshot()', parserOptions, errors },
-    { code: 'cy.get(".some-element").click().screenshot()', parserOptions, errors },
-    { code: 'if(true) { cy.get(".some-element").click(); cy.screenshot(); }', parserOptions, errors },
-    { code: 'cy.get(".some-element").click(); if(true) { cy.screenshot(); }', parserOptions, errors },
-    { code: 'cy.get(".some-element"); function a() { cy.screenshot(); }', parserOptions, errors },
-    { code: 'cy.get(".some-element"); const a = () => { cy.screenshot(); }', parserOptions, errors },
+    { code: 'cy.screenshot()', languageOptions, errors },
+    { code: 'cy.visit("somepage"); cy.screenshot();', languageOptions, errors },
+    { code: 'cy.custom(); cy.screenshot()', languageOptions, errors },
+    { code: 'cy.get(".some-element").click(); cy.screenshot()', languageOptions, errors },
+    { code: 'cy.get(".some-element").click().screenshot()', languageOptions, errors },
+    { code: 'if(true) { cy.get(".some-element").click(); cy.screenshot(); }', languageOptions, errors },
+    { code: 'cy.get(".some-element").click(); if(true) { cy.screenshot(); }', languageOptions, errors },
+    { code: 'cy.get(".some-element"); function a() { cy.screenshot(); }', languageOptions, errors },
+    { code: 'cy.get(".some-element"); const a = () => { cy.screenshot(); }', languageOptions, errors },
   ],
 })

--- a/tests/lib/rules/no-assigning-return-values.js
+++ b/tests/lib/rules/no-assigning-return-values.js
@@ -1,38 +1,38 @@
 'use strict'
 
 const rule = require('../../../lib/rules/no-assigning-return-values')
-const RuleTester = require('eslint').RuleTester
+const { FlatRuleTester } = require('eslint/use-at-your-own-risk')
 
-const ruleTester = new RuleTester()
+const ruleTester = new FlatRuleTester()
 
 const errors = [{ messageId: 'unexpected' }]
-const parserOptions = { ecmaVersion: 6 }
+const languageOptions = { ecmaVersion: 6 }
 
 ruleTester.run('no-assigning-return-values', rule, {
   valid: [
-    { code: 'var foo = true;', parserOptions },
-    { code: 'let foo = true;', parserOptions },
-    { code: 'const foo = true;', parserOptions },
-    { code: 'const foo = bar();', parserOptions },
-    { code: 'const foo = bar().baz();', parserOptions },
-    { code: 'const spy = cy.spy();', parserOptions },
-    { code: 'const spy = cy.spy().as();', parserOptions },
-    { code: 'const stub = cy.stub();', parserOptions },
-    { code: 'const result = cy.now();', parserOptions },
-    { code: 'const state = cy.state();', parserOptions },
-    { code: 'cy.get("foo");', parserOptions },
-    { code: 'cy.contains("foo").click();', parserOptions },
+    { code: 'var foo = true;', languageOptions },
+    { code: 'let foo = true;', languageOptions },
+    { code: 'const foo = true;', languageOptions },
+    { code: 'const foo = bar();', languageOptions },
+    { code: 'const foo = bar().baz();', languageOptions },
+    { code: 'const spy = cy.spy();', languageOptions },
+    { code: 'const spy = cy.spy().as();', languageOptions },
+    { code: 'const stub = cy.stub();', languageOptions },
+    { code: 'const result = cy.now();', languageOptions },
+    { code: 'const state = cy.state();', languageOptions },
+    { code: 'cy.get("foo");', languageOptions },
+    { code: 'cy.contains("foo").click();', languageOptions },
   ],
 
   invalid: [
-    { code: 'let a = cy.get("foo")', parserOptions, errors },
-    { code: 'const a = cy.get("foo")', parserOptions, errors },
-    { code: 'var a = cy.get("foo")', parserOptions, errors },
+    { code: 'let a = cy.get("foo")', languageOptions, errors },
+    { code: 'const a = cy.get("foo")', languageOptions, errors },
+    { code: 'var a = cy.get("foo")', languageOptions, errors },
 
-    { code: 'let a = cy.contains("foo")', parserOptions, errors },
-    { code: 'let a = cy.window()', parserOptions, errors },
-    { code: 'let a = cy.wait("@something")', parserOptions, errors },
+    { code: 'let a = cy.contains("foo")', languageOptions, errors },
+    { code: 'let a = cy.window()', languageOptions, errors },
+    { code: 'let a = cy.wait("@something")', languageOptions, errors },
 
-    { code: 'let a = cy.contains("foo").click()', parserOptions, errors },
+    { code: 'let a = cy.contains("foo").click()', languageOptions, errors },
   ],
 })

--- a/tests/lib/rules/no-async-before.js
+++ b/tests/lib/rules/no-async-before.js
@@ -1,25 +1,25 @@
 'use strict'
 
 const rule = require('../../../lib/rules/no-async-before')
-const RuleTester = require('eslint').RuleTester
+const { FlatRuleTester } = require('eslint/use-at-your-own-risk')
 
-const ruleTester = new RuleTester()
+const ruleTester = new FlatRuleTester()
 
 const errors = [{ messageId: 'unexpected' }]
 // async functions are an ES2017 feature
-const parserOptions = { ecmaVersion: 8 }
+const languageOptions = { ecmaVersion: 8 }
 
 ruleTester.run('no-async-before', rule, {
   valid: [
-    { code: 'before(\'a before case\', () => { cy.get(\'.someClass\'); })', parserOptions },
-    { code: 'before(\'a before case\', async () => { await somethingAsync(); })', parserOptions },
-    { code: 'async function nonTestFn () { return await somethingAsync(); }', parserOptions },
-    { code: 'const nonTestArrowFn = async () => { await somethingAsync(); }', parserOptions },
+    { code: 'before(\'a before case\', () => { cy.get(\'.someClass\'); })', languageOptions },
+    { code: 'before(\'a before case\', async () => { await somethingAsync(); })', languageOptions },
+    { code: 'async function nonTestFn () { return await somethingAsync(); }', languageOptions },
+    { code: 'const nonTestArrowFn = async () => { await somethingAsync(); }', languageOptions },
   ],
   invalid: [
-    { code: 'before(\'a test case\', async () => { cy.get(\'.someClass\'); })', parserOptions, errors },
-    { code: 'beforeEach(\'a test case\', async () => { cy.get(\'.someClass\'); })', parserOptions, errors },
-    { code: 'before(\'a test case\', async function () { cy.get(\'.someClass\'); })', parserOptions, errors },
-    { code: 'beforeEach(\'a test case\', async function () { cy.get(\'.someClass\'); })', parserOptions, errors },
+    { code: 'before(\'a test case\', async () => { cy.get(\'.someClass\'); })', languageOptions, errors },
+    { code: 'beforeEach(\'a test case\', async () => { cy.get(\'.someClass\'); })', languageOptions, errors },
+    { code: 'before(\'a test case\', async function () { cy.get(\'.someClass\'); })', languageOptions, errors },
+    { code: 'beforeEach(\'a test case\', async function () { cy.get(\'.someClass\'); })', languageOptions, errors },
   ],
 })

--- a/tests/lib/rules/no-async-tests.js
+++ b/tests/lib/rules/no-async-tests.js
@@ -1,25 +1,25 @@
 'use strict'
 
 const rule = require('../../../lib/rules/no-async-tests')
-const RuleTester = require('eslint').RuleTester
+const { FlatRuleTester } = require('eslint/use-at-your-own-risk')
 
-const ruleTester = new RuleTester()
+const ruleTester = new FlatRuleTester()
 
 const errors = [{ messageId: 'unexpected' }]
 // async functions are an ES2017 feature
-const parserOptions = { ecmaVersion: 8 }
+const languageOptions = { ecmaVersion: 8 }
 
 ruleTester.run('no-async-tests', rule, {
   valid: [
-    { code: 'it(\'a test case\', () => { cy.get(\'.someClass\'); })', parserOptions },
-    { code: 'it(\'a test case\', async () => { await somethingAsync(); })', parserOptions },
-    { code: 'async function nonTestFn () { return await somethingAsync(); }', parserOptions },
-    { code: 'const nonTestArrowFn = async () => { await somethingAsync(); }', parserOptions },
+    { code: 'it(\'a test case\', () => { cy.get(\'.someClass\'); })', languageOptions },
+    { code: 'it(\'a test case\', async () => { await somethingAsync(); })', languageOptions },
+    { code: 'async function nonTestFn () { return await somethingAsync(); }', languageOptions },
+    { code: 'const nonTestArrowFn = async () => { await somethingAsync(); }', languageOptions },
   ],
   invalid: [
-    { code: 'it(\'a test case\', async () => { cy.get(\'.someClass\'); })', parserOptions, errors },
-    { code: 'test(\'a test case\', async () => { cy.get(\'.someClass\'); })', parserOptions, errors },
-    { code: 'it(\'a test case\', async function () { cy.get(\'.someClass\'); })', parserOptions, errors },
-    { code: 'test(\'a test case\', async function () { cy.get(\'.someClass\'); })', parserOptions, errors },
+    { code: 'it(\'a test case\', async () => { cy.get(\'.someClass\'); })', languageOptions, errors },
+    { code: 'test(\'a test case\', async () => { cy.get(\'.someClass\'); })', languageOptions, errors },
+    { code: 'it(\'a test case\', async function () { cy.get(\'.someClass\'); })', languageOptions, errors },
+    { code: 'test(\'a test case\', async function () { cy.get(\'.someClass\'); })', languageOptions, errors },
   ],
 })

--- a/tests/lib/rules/no-force.js
+++ b/tests/lib/rules/no-force.js
@@ -6,44 +6,44 @@
 
 const rule = require('../../../lib/rules/no-force')
 
-const RuleTester = require('eslint').RuleTester
+const { FlatRuleTester } = require('eslint/use-at-your-own-risk')
 
 const errors = [{ messageId: 'unexpected' }]
-const parserOptions = { ecmaVersion: 2018 }
+const languageOptions = { ecmaVersion: 2018 }
 
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
 
-let ruleTester = new RuleTester()
+let ruleTester = new FlatRuleTester()
 
 ruleTester.run('no-force', rule, {
 
   valid: [
-    { code: `cy.get('button').click()`, parserOptions },
-    { code: `cy.get('button').click({multiple: true})`, parserOptions },
-    { code: `cy.get('button').dblclick()`, parserOptions },
-    { code: `cy.get('input').type('somth')`, parserOptions },
-    { code: `cy.get('input').type('somth', {anyoption: true})`, parserOptions },
-    { code: `cy.get('input').trigger('click', {anyoption: true})`, parserOptions },
-    { code: `cy.get('input').rightclick({anyoption: true})`, parserOptions },
-    { code: `cy.get('input').check()`, parserOptions },
-    { code: `cy.get('input').select()`, parserOptions },
-    { code: `cy.get('input').focus()`, parserOptions },
-    { code: `cy.document().trigger("keydown", { ...event })`, parserOptions },
+    { code: `cy.get('button').click()`, languageOptions },
+    { code: `cy.get('button').click({multiple: true})`, languageOptions },
+    { code: `cy.get('button').dblclick()`, languageOptions },
+    { code: `cy.get('input').type('somth')`, languageOptions },
+    { code: `cy.get('input').type('somth', {anyoption: true})`, languageOptions },
+    { code: `cy.get('input').trigger('click', {anyoption: true})`, languageOptions },
+    { code: `cy.get('input').rightclick({anyoption: true})`, languageOptions },
+    { code: `cy.get('input').check()`, languageOptions },
+    { code: `cy.get('input').select()`, languageOptions },
+    { code: `cy.get('input').focus()`, languageOptions },
+    { code: `cy.document().trigger("keydown", { ...event })`, languageOptions },
   ],
 
   invalid: [
-    { code: `cy.get('button').click({force: true})`, parserOptions, errors },
-    { code: `cy.get('button').dblclick({force: true})`, parserOptions, errors },
-    { code: `cy.get('input').type('somth', {force: true})`, parserOptions, errors },
-    { code: `cy.get('div').find('.foo').type('somth', {force: true})`, parserOptions, errors },
-    { code: `cy.get('div').find('.foo').find('.bar').click({force: true})`, parserOptions, errors },
-    { code: `cy.get('div').find('.foo').find('.bar').trigger('change', {force: true})`, parserOptions, errors },
-    { code: `cy.get('input').trigger('click', {force: true})`, parserOptions, errors },
-    { code: `cy.get('input').rightclick({force: true})`, parserOptions, errors },
-    { code: `cy.get('input').check({force: true})`, parserOptions, errors },
-    { code: `cy.get('input').select({force: true})`, parserOptions, errors },
-    { code: `cy.get('input').focus({force: true})`, parserOptions, errors },
+    { code: `cy.get('button').click({force: true})`, languageOptions, errors },
+    { code: `cy.get('button').dblclick({force: true})`, languageOptions, errors },
+    { code: `cy.get('input').type('somth', {force: true})`, languageOptions, errors },
+    { code: `cy.get('div').find('.foo').type('somth', {force: true})`, languageOptions, errors },
+    { code: `cy.get('div').find('.foo').find('.bar').click({force: true})`, languageOptions, errors },
+    { code: `cy.get('div').find('.foo').find('.bar').trigger('change', {force: true})`, languageOptions, errors },
+    { code: `cy.get('input').trigger('click', {force: true})`, languageOptions, errors },
+    { code: `cy.get('input').rightclick({force: true})`, languageOptions, errors },
+    { code: `cy.get('input').check({force: true})`, languageOptions, errors },
+    { code: `cy.get('input').select({force: true})`, languageOptions, errors },
+    { code: `cy.get('input').focus({force: true})`, languageOptions, errors },
   ],
 })

--- a/tests/lib/rules/no-pause.js
+++ b/tests/lib/rules/no-pause.js
@@ -6,32 +6,32 @@
 
 const rule = require('../../../lib/rules/no-pause')
 
-const RuleTester = require('eslint').RuleTester
+const { FlatRuleTester } = require('eslint/use-at-your-own-risk')
 
 const errors = [{ messageId: 'unexpected' }]
-const parserOptions = { ecmaVersion: 2018 }
+const languageOptions = { ecmaVersion: 2018 }
 
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester()
+const ruleTester = new FlatRuleTester()
 
 ruleTester.run('no-pause', rule, {
 
   valid: [
-    { code: `pause()`, parserOptions },
-    { code: `cy.get('button').dblclick()`, parserOptions },
+    { code: `pause()`, languageOptions },
+    { code: `cy.get('button').dblclick()`, languageOptions },
   ],
-  
+
   invalid: [
-    { code: `cy.pause()`, parserOptions, errors },
-    { code: `cy.pause({ log: false })`, parserOptions, errors },
-    { code: `cy.get('button').pause()`, parserOptions, errors },
-    { 
-      code: `cy.get('a').should('have.attr', 'href').and('match', /dashboard/).pause()`, 
-      parserOptions, 
-      errors 
+    { code: `cy.pause()`, languageOptions, errors },
+    { code: `cy.pause({ log: false })`, languageOptions, errors },
+    { code: `cy.get('button').pause()`, languageOptions, errors },
+    {
+      code: `cy.get('a').should('have.attr', 'href').and('match', /dashboard/).pause()`,
+      languageOptions,
+      errors
     }
   ],
 })

--- a/tests/lib/rules/no-unnecessary-waiting.js
+++ b/tests/lib/rules/no-unnecessary-waiting.js
@@ -1,71 +1,48 @@
 'use strict'
 
 const rule = require('../../../lib/rules/no-unnecessary-waiting')
-const RuleTester = require('eslint').RuleTester
+const { FlatRuleTester } = require('eslint/use-at-your-own-risk')
 
-const ruleTester = new RuleTester()
+const ruleTester = new FlatRuleTester()
 
 const errors = [{ messageId: 'unexpected' }]
-const parserOptions = { ecmaVersion: 6, sourceType: 'module' }
+const languageOptions = { ecmaVersion: 6, sourceType: 'module' }
 
 ruleTester.run('no-unnecessary-waiting', rule, {
   valid: [
-    { code: 'foo.wait(10)', parserOptions },
+    { code: 'foo.wait(10)', languageOptions },
 
-    { code: 'cy.wait("@someRequest")', parserOptions },
-    { code: 'cy.wait("@someRequest", { log: false })', parserOptions },
-    { code: 'cy.wait("@someRequest").then((xhr) => xhr)', parserOptions },
-    { code: 'cy.wait(["@someRequest", "@anotherRequest"])', parserOptions },
+    { code: 'cy.wait("@someRequest")', languageOptions },
+    { code: 'cy.wait("@someRequest", { log: false })', languageOptions },
+    { code: 'cy.wait("@someRequest").then((xhr) => xhr)', languageOptions },
+    { code: 'cy.wait(["@someRequest", "@anotherRequest"])', languageOptions },
 
-    { code: 'cy.clock(5000)', parserOptions },
-    { code: 'cy.scrollTo(0, 10)', parserOptions },
-    { code: 'cy.tick(500)', parserOptions },
+    { code: 'cy.clock(5000)', languageOptions },
+    { code: 'cy.scrollTo(0, 10)', languageOptions },
+    { code: 'cy.tick(500)', languageOptions },
 
-    { code: 'const someRequest="@someRequest"; cy.wait(someRequest)', parserOptions, errors },
-    { code: 'function customWait (alias = "@someRequest") { cy.wait(alias) }', parserOptions, errors },
-    { code: 'const customWait = (alias = "@someRequest") => { cy.wait(alias) }', parserOptions, errors },
-    { code: 'function customWait (ms) { cy.wait(ms) }', parserOptions, errors },
-    { code: 'const customWait = (ms) => { cy.wait(ms) }', parserOptions, errors },
+    { code: 'const someRequest="@someRequest"; cy.wait(someRequest)', languageOptions, errors },
+    { code: 'function customWait (alias = "@someRequest") { cy.wait(alias) }', languageOptions, errors },
+    { code: 'const customWait = (alias = "@someRequest") => { cy.wait(alias) }', languageOptions, errors },
+    { code: 'function customWait (ms) { cy.wait(ms) }', languageOptions, errors },
+    { code: 'const customWait = (ms) => { cy.wait(ms) }', languageOptions, errors },
 
-    { code: 'import BAR_BAZ from "bar-baz"; cy.wait(BAR_BAZ)', parserOptions },
-    { code: 'import { FOO_BAR } from "foo-bar"; cy.wait(FOO_BAR)', parserOptions },
-    { code: 'import * as wildcard from "wildcard"; cy.wait(wildcard.value)', parserOptions },
-    { code: 'import { NAME as OTHER_NAME } from "rename"; cy.wait(OTHER_NAME)', parserOptions },
-
-    // disable the eslint rule
-    {
-      code: `
-        cy.wait(100); // eslint-disable-line no-unnecessary-waiting
-      `,
-      parserOptions,
-    },
-    {
-      code: `
-        /* eslint-disable-next-line no-unnecessary-waiting */
-        cy.wait(100)
-      `,
-      parserOptions,
-    },
-    {
-      code: `
-        /* eslint-disable no-unnecessary-waiting */
-        cy.wait(100)
-        /* eslint-enable no-unnecessary-waiting */
-      `,
-      parserOptions,
-    },
+    { code: 'import BAR_BAZ from "bar-baz"; cy.wait(BAR_BAZ)', languageOptions },
+    { code: 'import { FOO_BAR } from "foo-bar"; cy.wait(FOO_BAR)', languageOptions },
+    { code: 'import * as wildcard from "wildcard"; cy.wait(wildcard.value)', languageOptions },
+    { code: 'import { NAME as OTHER_NAME } from "rename"; cy.wait(OTHER_NAME)', languageOptions },
   ],
 
   invalid: [
-    { code: 'cy.wait(0)', parserOptions, errors },
-    { code: 'cy.wait(100)', parserOptions, errors },
-    { code: 'cy.wait(5000)', parserOptions, errors },
-    { code: 'const someNumber=500; cy.wait(someNumber)', parserOptions, errors },
-    { code: 'function customWait (ms = 1) { cy.wait(ms) }', parserOptions, errors },
-    { code: 'const customWait = (ms = 1) => { cy.wait(ms) }', parserOptions, errors },
+    { code: 'cy.wait(0)', languageOptions, errors },
+    { code: 'cy.wait(100)', languageOptions, errors },
+    { code: 'cy.wait(5000)', languageOptions, errors },
+    { code: 'const someNumber=500; cy.wait(someNumber)', languageOptions, errors },
+    { code: 'function customWait (ms = 1) { cy.wait(ms) }', languageOptions, errors },
+    { code: 'const customWait = (ms = 1) => { cy.wait(ms) }', languageOptions, errors },
 
-    { code: 'cy.get(".some-element").wait(10)', parserOptions, errors },
-    { code: 'cy.get(".some-element").contains("foo").wait(10)', parserOptions, errors },
-    { code: 'const customWait = (ms = 1) => { cy.get(".some-element").wait(ms) }', parserOptions, errors },
+    { code: 'cy.get(".some-element").wait(10)', languageOptions, errors },
+    { code: 'cy.get(".some-element").contains("foo").wait(10)', languageOptions, errors },
+    { code: 'const customWait = (ms = 1) => { cy.get(".some-element").wait(ms) }', languageOptions, errors },
   ],
 })

--- a/tests/lib/rules/require-data-selectors.js
+++ b/tests/lib/rules/require-data-selectors.js
@@ -1,31 +1,31 @@
 'use strict'
 
 const rule = require('../../../lib/rules/require-data-selectors')
-const RuleTester = require('eslint').RuleTester
+const { FlatRuleTester } = require('eslint/use-at-your-own-risk')
 
-const ruleTester = new RuleTester()
+const ruleTester = new FlatRuleTester()
 
 const errors = [{ messageId: 'unexpected' }]
-const parserOptions = { ecmaVersion: 6 }
+const languageOptions = { ecmaVersion: 6 }
 
 ruleTester.run('require-data-selectors', rule, {
   valid: [
-    { code: 'cy.get(\'[data-cy=submit]\').click()', parserOptions },
-    { code: 'cy.get(\'[data-QA=submit]\')', parserOptions },
-    { code: 'cy.clock(5000)', parserOptions },
-    { code: 'cy.scrollTo(0, 10)', parserOptions },
-    { code: 'cy.tick(500)', parserOptions },
-    { code: 'cy.get(\`[data-cy=${1}]\`)', parserOptions }, // eslint-disable-line no-useless-escape
-    { code: 'cy.get("@my-alias")', parserOptions, errors },
-    { code: 'cy.get(`@my-alias`)', parserOptions, errors },
+    { code: 'cy.get(\'[data-cy=submit]\').click()', languageOptions },
+    { code: 'cy.get(\'[data-QA=submit]\')', languageOptions },
+    { code: 'cy.clock(5000)', languageOptions },
+    { code: 'cy.scrollTo(0, 10)', languageOptions },
+    { code: 'cy.tick(500)', languageOptions },
+    { code: 'cy.get(\`[data-cy=${1}]\`)', languageOptions }, // eslint-disable-line no-useless-escape
+    { code: 'cy.get("@my-alias")', languageOptions, errors },
+    { code: 'cy.get(`@my-alias`)', languageOptions, errors },
   ],
 
   invalid: [
-    { code: 'cy.get(\'[daedta-cy=submit]\').click()', parserOptions, errors },
-    { code: 'cy.get(\'[d-cy=submit]\')', parserOptions, errors },
-    { code: 'cy.get(".btn-large").click()', parserOptions, errors },
-    { code: 'cy.get(".btn-.large").click()', parserOptions, errors },
-    { code: 'cy.get(".a")', parserOptions, errors },
-    { code: 'cy.get(\`[daedta-cy=${1}]\`)', parserOptions, errors }, // eslint-disable-line no-useless-escape
+    { code: 'cy.get(\'[daedta-cy=submit]\').click()', languageOptions, errors },
+    { code: 'cy.get(\'[d-cy=submit]\')', languageOptions, errors },
+    { code: 'cy.get(".btn-large").click()', languageOptions, errors },
+    { code: 'cy.get(".btn-.large").click()', languageOptions, errors },
+    { code: 'cy.get(".a")', languageOptions, errors },
+    { code: 'cy.get(\`[daedta-cy=${1}]\`)', languageOptions, errors }, // eslint-disable-line no-useless-escape
   ],
 })

--- a/tests/lib/rules/unsafe-to-chain-command.js
+++ b/tests/lib/rules/unsafe-to-chain-command.js
@@ -1,56 +1,56 @@
 'use strict'
 
 const rule = require('../../../lib/rules/unsafe-to-chain-command')
-const RuleTester = require('eslint').RuleTester
+const { FlatRuleTester } = require('eslint/use-at-your-own-risk')
 
-const ruleTester = new RuleTester()
+const ruleTester = new FlatRuleTester()
 
 const errors = [{ messageId: 'unexpected' }]
-const parserOptions = { ecmaVersion: 6 }
+const languageOptions = { ecmaVersion: 6 }
 
 ruleTester.run('action-ends-chain', rule, {
   valid: [
     {
       code: 'cy.get("new-todo").type("todo A{enter}"); cy.get("new-todo").type("todo B{enter}"); cy.get("new-todo").should("have.class", "active");',
-      parserOptions,
+      languageOptions,
     },
     {
       code: 'cy.focused().should("be.visible");',
-      parserOptions,
+      languageOptions,
     },
     {
       code: 'cy.submitBtn().click();',
-      parserOptions,
+      languageOptions,
     },
   ],
 
   invalid: [
     {
       code: 'cy.get("new-todo").type("todo A{enter}").should("have.class", "active");',
-      parserOptions,
+      languageOptions,
       errors,
     },
     {
       code: 'cy.get("new-todo").type("todo A{enter}").type("todo B{enter}");',
-      parserOptions,
+      languageOptions,
       errors,
     },
     {
       code: 'cy.get("new-todo").focus().should("have.class", "active");',
-      parserOptions,
+      languageOptions,
       errors,
     },
     {
       code: 'cy.get("new-todo").customType("todo A{enter}").customClick();',
-      parserOptions,
+      languageOptions,
       errors,
       options: [{ methods: ['customType', 'customClick'] }],
     },
     {
       code: 'cy.get("new-todo").customPress("Enter").customScroll();',
-      parserOptions,
+      languageOptions,
       errors,
-      options: [{ methods: [/customPress/, /customScroll/] }],
+      options: [{ methods: ['customPress', 'customScroll'] }],
     },
   ],
 })


### PR DESCRIPTION
## Issue

Tests in the [tests/lib/rules](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/tests/lib/rules) directory which run internally under ESLint `8.x` are not compatible with ESLint `9.x`.

The guide [Migrate to 9.0 > FlatRuleTester is now RuleTester](https://eslint.org/docs/latest/use/migrate-to-9.0.0#flat-rule-tester) explain:

> As announced in our [blog post](https://eslint.org/blog/2023/10/flat-config-rollout-plans/), the temporary FlatRuleTester class has been renamed to RuleTester, while the RuleTester class from v8.x has been removed. Additionally, the FlatRuleTester export from eslint/use-at-your-own-risk has been removed.

This is a breaking change for the tests.

## Migration steps

The migration is done in two steps:

1. Migrate to the temporary `FlatRuleTester` class in ESLint `8.x`
2. Migrate to the new RuleTester class in ESLint `9.x` and at the same time migrate to using ESLint `9.x` internally.

## Changes

This PR deals with the first step of migrating to the temporary `FlatRuleTester` class in ESLint `8.x`.

A follow-on PR will take care of the second step of migrating to ESLint `9.x`

For all [tests/lib/rules](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/tests/lib/rules) `*.js` test files
1. Use `const { FlatRuleTester } = require('eslint/use-at-your-own-risk')` according to the blog post [Testing rules with flat config and the RuleTester class](https://eslint.org/blog/2022/08/new-config-system-part-3/#testing-rules-with-flat-config-and-the-ruletester-class).
2. Change `parserOptions` to `languageOptions`.
3. For [tests/lib/rules/no-unnecessary-waiting.js](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/tests/lib/rules/no-unnecessary-waiting.js) remove the section which attempts to test disabling the rule. This is not compatible with the FlatRuleTester and it is attempting to test a function of ESLint rather than the rule itself.
3. For [tests/lib/rules/unsafe-to-chain-command.js](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/tests/lib/rules/unsafe-to-chain-command.js) modify an incompatible option syntax in one rule.

## References

- [Testing rules with flat config and the RuleTester class](https://eslint.org/blog/2022/08/new-config-system-part-3/#testing-rules-with-flat-config-and-the-ruletester-class)
- [FlatRuleTester is now RuleTester](https://eslint.org/docs/latest/use/migrate-to-9.0.0#flat-rule-tester)
- [v9 > RuleTester](https://eslint.org/docs/latest/integrate/nodejs-api#ruletester)

## Verification

Ubuntu `22.04.4` LTS, Node.js `v20.12.2` LTS

```shell
npm ci
npm run test
```
