### PR TITLE
tests: save legacy tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -52,7 +52,7 @@ jobs:
           command: npx eslint --version
       - run:
           name: Test ESLint 7
-          command: npm test
+          command: npm run test:legacy
 
   test-v8:
     docker:
@@ -70,7 +70,7 @@ jobs:
           command: npx eslint --version
       - run:
           name: Test ESLint 8
-          command: npm test
+          command: npm run test:legacy
 
   release:
     docker:

--- a/jest.config-legacy.js
+++ b/jest.config-legacy.js
@@ -1,0 +1,6 @@
+const { defaults } = require('jest-config')
+
+module.exports = {
+  testMatch: ['**/tests-legacy/**/*.[jt]s?(x)'],
+  testPathIgnorePatterns: [...defaults.testPathIgnorePatterns, '.history'],
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "semantic-release": "semantic-release",
     "start": "npm run test-watch",
     "test": "jest",
+    "test:legacy": "jest --config jest.config-legacy.js",
     "test-watch": "jest --watchAll",
     "prepare": "husky"
   }

--- a/tests-legacy/config.js
+++ b/tests-legacy/config.js
@@ -1,0 +1,26 @@
+/* global describe, it, expect */
+'use strict'
+
+const globals = require('globals')
+const config = require('../index.js')
+
+describe('environments globals', () => {
+  const env = config.environments.globals
+
+  it('should not mutate globals', () => {
+    expect(globals.browser).not.toHaveProperty('cy')
+    expect(globals.mocha).not.toHaveProperty('cy')
+  })
+
+  it('should include other globals', () => {
+    expect(env.globals).toEqual(expect.objectContaining(globals.browser))
+    expect(env.globals).toEqual(expect.objectContaining(globals.mocha))
+  })
+
+  it('should include cypress globals', () => {
+    expect(env.globals).toEqual(expect.objectContaining({
+      cy: false,
+      Cypress: false,
+    }))
+  })
+})

--- a/tests-legacy/lib/rules/assertion-before-screenshot.js
+++ b/tests-legacy/lib/rules/assertion-before-screenshot.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const rule = require('../../../lib/rules/assertion-before-screenshot')
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester()
+
+const errors = [{ messageId: 'unexpected' }]
+const parserOptions = { ecmaVersion: 6 }
+
+ruleTester.run('assertion-before-screenshot', rule, {
+  valid: [
+    { code: 'cy.get(".some-element"); cy.screenshot();', parserOptions },
+    { code: 'cy.get(".some-element").should("exist").screenshot();', parserOptions },
+    { code: 'cy.get(".some-element").should("exist").screenshot().click()', parserOptions, errors },
+    { code: 'cy.get(".some-element").should("exist"); if(true) cy.screenshot();', parserOptions },
+    { code: 'if(true) { cy.get(".some-element").should("exist"); cy.screenshot(); }', parserOptions },
+    { code: 'cy.get(".some-element").should("exist"); if(true) { cy.screenshot(); }', parserOptions },
+    { code: 'const a = () => { cy.get(".some-element").should("exist"); cy.screenshot(); }', parserOptions, errors },
+    { code: 'cy.get(".some-element").should("exist").and("be.visible"); cy.screenshot();', parserOptions },
+    { code: 'cy.get(".some-element").contains("Text"); cy.screenshot();', parserOptions },
+  ],
+
+  invalid: [
+    { code: 'cy.screenshot()', parserOptions, errors },
+    { code: 'cy.visit("somepage"); cy.screenshot();', parserOptions, errors },
+    { code: 'cy.custom(); cy.screenshot()', parserOptions, errors },
+    { code: 'cy.get(".some-element").click(); cy.screenshot()', parserOptions, errors },
+    { code: 'cy.get(".some-element").click().screenshot()', parserOptions, errors },
+    { code: 'if(true) { cy.get(".some-element").click(); cy.screenshot(); }', parserOptions, errors },
+    { code: 'cy.get(".some-element").click(); if(true) { cy.screenshot(); }', parserOptions, errors },
+    { code: 'cy.get(".some-element"); function a() { cy.screenshot(); }', parserOptions, errors },
+    { code: 'cy.get(".some-element"); const a = () => { cy.screenshot(); }', parserOptions, errors },
+  ],
+})

--- a/tests-legacy/lib/rules/no-assigning-return-values.js
+++ b/tests-legacy/lib/rules/no-assigning-return-values.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const rule = require('../../../lib/rules/no-assigning-return-values')
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester()
+
+const errors = [{ messageId: 'unexpected' }]
+const parserOptions = { ecmaVersion: 6 }
+
+ruleTester.run('no-assigning-return-values', rule, {
+  valid: [
+    { code: 'var foo = true;', parserOptions },
+    { code: 'let foo = true;', parserOptions },
+    { code: 'const foo = true;', parserOptions },
+    { code: 'const foo = bar();', parserOptions },
+    { code: 'const foo = bar().baz();', parserOptions },
+    { code: 'const spy = cy.spy();', parserOptions },
+    { code: 'const spy = cy.spy().as();', parserOptions },
+    { code: 'const stub = cy.stub();', parserOptions },
+    { code: 'const result = cy.now();', parserOptions },
+    { code: 'const state = cy.state();', parserOptions },
+    { code: 'cy.get("foo");', parserOptions },
+    { code: 'cy.contains("foo").click();', parserOptions },
+  ],
+
+  invalid: [
+    { code: 'let a = cy.get("foo")', parserOptions, errors },
+    { code: 'const a = cy.get("foo")', parserOptions, errors },
+    { code: 'var a = cy.get("foo")', parserOptions, errors },
+
+    { code: 'let a = cy.contains("foo")', parserOptions, errors },
+    { code: 'let a = cy.window()', parserOptions, errors },
+    { code: 'let a = cy.wait("@something")', parserOptions, errors },
+
+    { code: 'let a = cy.contains("foo").click()', parserOptions, errors },
+  ],
+})

--- a/tests-legacy/lib/rules/no-async-before.js
+++ b/tests-legacy/lib/rules/no-async-before.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const rule = require('../../../lib/rules/no-async-before')
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester()
+
+const errors = [{ messageId: 'unexpected' }]
+// async functions are an ES2017 feature
+const parserOptions = { ecmaVersion: 8 }
+
+ruleTester.run('no-async-before', rule, {
+  valid: [
+    { code: 'before(\'a before case\', () => { cy.get(\'.someClass\'); })', parserOptions },
+    { code: 'before(\'a before case\', async () => { await somethingAsync(); })', parserOptions },
+    { code: 'async function nonTestFn () { return await somethingAsync(); }', parserOptions },
+    { code: 'const nonTestArrowFn = async () => { await somethingAsync(); }', parserOptions },
+  ],
+  invalid: [
+    { code: 'before(\'a test case\', async () => { cy.get(\'.someClass\'); })', parserOptions, errors },
+    { code: 'beforeEach(\'a test case\', async () => { cy.get(\'.someClass\'); })', parserOptions, errors },
+    { code: 'before(\'a test case\', async function () { cy.get(\'.someClass\'); })', parserOptions, errors },
+    { code: 'beforeEach(\'a test case\', async function () { cy.get(\'.someClass\'); })', parserOptions, errors },
+  ],
+})

--- a/tests-legacy/lib/rules/no-async-tests.js
+++ b/tests-legacy/lib/rules/no-async-tests.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const rule = require('../../../lib/rules/no-async-tests')
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester()
+
+const errors = [{ messageId: 'unexpected' }]
+// async functions are an ES2017 feature
+const parserOptions = { ecmaVersion: 8 }
+
+ruleTester.run('no-async-tests', rule, {
+  valid: [
+    { code: 'it(\'a test case\', () => { cy.get(\'.someClass\'); })', parserOptions },
+    { code: 'it(\'a test case\', async () => { await somethingAsync(); })', parserOptions },
+    { code: 'async function nonTestFn () { return await somethingAsync(); }', parserOptions },
+    { code: 'const nonTestArrowFn = async () => { await somethingAsync(); }', parserOptions },
+  ],
+  invalid: [
+    { code: 'it(\'a test case\', async () => { cy.get(\'.someClass\'); })', parserOptions, errors },
+    { code: 'test(\'a test case\', async () => { cy.get(\'.someClass\'); })', parserOptions, errors },
+    { code: 'it(\'a test case\', async function () { cy.get(\'.someClass\'); })', parserOptions, errors },
+    { code: 'test(\'a test case\', async function () { cy.get(\'.someClass\'); })', parserOptions, errors },
+  ],
+})

--- a/tests-legacy/lib/rules/no-force.js
+++ b/tests-legacy/lib/rules/no-force.js
@@ -1,0 +1,49 @@
+'use strict'
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/no-force')
+
+const RuleTester = require('eslint').RuleTester
+
+const errors = [{ messageId: 'unexpected' }]
+const parserOptions = { ecmaVersion: 2018 }
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+let ruleTester = new RuleTester()
+
+ruleTester.run('no-force', rule, {
+
+  valid: [
+    { code: `cy.get('button').click()`, parserOptions },
+    { code: `cy.get('button').click({multiple: true})`, parserOptions },
+    { code: `cy.get('button').dblclick()`, parserOptions },
+    { code: `cy.get('input').type('somth')`, parserOptions },
+    { code: `cy.get('input').type('somth', {anyoption: true})`, parserOptions },
+    { code: `cy.get('input').trigger('click', {anyoption: true})`, parserOptions },
+    { code: `cy.get('input').rightclick({anyoption: true})`, parserOptions },
+    { code: `cy.get('input').check()`, parserOptions },
+    { code: `cy.get('input').select()`, parserOptions },
+    { code: `cy.get('input').focus()`, parserOptions },
+    { code: `cy.document().trigger("keydown", { ...event })`, parserOptions },
+  ],
+
+  invalid: [
+    { code: `cy.get('button').click({force: true})`, parserOptions, errors },
+    { code: `cy.get('button').dblclick({force: true})`, parserOptions, errors },
+    { code: `cy.get('input').type('somth', {force: true})`, parserOptions, errors },
+    { code: `cy.get('div').find('.foo').type('somth', {force: true})`, parserOptions, errors },
+    { code: `cy.get('div').find('.foo').find('.bar').click({force: true})`, parserOptions, errors },
+    { code: `cy.get('div').find('.foo').find('.bar').trigger('change', {force: true})`, parserOptions, errors },
+    { code: `cy.get('input').trigger('click', {force: true})`, parserOptions, errors },
+    { code: `cy.get('input').rightclick({force: true})`, parserOptions, errors },
+    { code: `cy.get('input').check({force: true})`, parserOptions, errors },
+    { code: `cy.get('input').select({force: true})`, parserOptions, errors },
+    { code: `cy.get('input').focus({force: true})`, parserOptions, errors },
+  ],
+})

--- a/tests-legacy/lib/rules/no-pause.js
+++ b/tests-legacy/lib/rules/no-pause.js
@@ -1,0 +1,37 @@
+'use strict'
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/no-pause')
+
+const RuleTester = require('eslint').RuleTester
+
+const errors = [{ messageId: 'unexpected' }]
+const parserOptions = { ecmaVersion: 2018 }
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester()
+
+ruleTester.run('no-pause', rule, {
+
+  valid: [
+    { code: `pause()`, parserOptions },
+    { code: `cy.get('button').dblclick()`, parserOptions },
+  ],
+  
+  invalid: [
+    { code: `cy.pause()`, parserOptions, errors },
+    { code: `cy.pause({ log: false })`, parserOptions, errors },
+    { code: `cy.get('button').pause()`, parserOptions, errors },
+    { 
+      code: `cy.get('a').should('have.attr', 'href').and('match', /dashboard/).pause()`, 
+      parserOptions, 
+      errors 
+    }
+  ],
+})

--- a/tests-legacy/lib/rules/no-unnecessary-waiting.js
+++ b/tests-legacy/lib/rules/no-unnecessary-waiting.js
@@ -1,0 +1,71 @@
+'use strict'
+
+const rule = require('../../../lib/rules/no-unnecessary-waiting')
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester()
+
+const errors = [{ messageId: 'unexpected' }]
+const parserOptions = { ecmaVersion: 6, sourceType: 'module' }
+
+ruleTester.run('no-unnecessary-waiting', rule, {
+  valid: [
+    { code: 'foo.wait(10)', parserOptions },
+
+    { code: 'cy.wait("@someRequest")', parserOptions },
+    { code: 'cy.wait("@someRequest", { log: false })', parserOptions },
+    { code: 'cy.wait("@someRequest").then((xhr) => xhr)', parserOptions },
+    { code: 'cy.wait(["@someRequest", "@anotherRequest"])', parserOptions },
+
+    { code: 'cy.clock(5000)', parserOptions },
+    { code: 'cy.scrollTo(0, 10)', parserOptions },
+    { code: 'cy.tick(500)', parserOptions },
+
+    { code: 'const someRequest="@someRequest"; cy.wait(someRequest)', parserOptions, errors },
+    { code: 'function customWait (alias = "@someRequest") { cy.wait(alias) }', parserOptions, errors },
+    { code: 'const customWait = (alias = "@someRequest") => { cy.wait(alias) }', parserOptions, errors },
+    { code: 'function customWait (ms) { cy.wait(ms) }', parserOptions, errors },
+    { code: 'const customWait = (ms) => { cy.wait(ms) }', parserOptions, errors },
+
+    { code: 'import BAR_BAZ from "bar-baz"; cy.wait(BAR_BAZ)', parserOptions },
+    { code: 'import { FOO_BAR } from "foo-bar"; cy.wait(FOO_BAR)', parserOptions },
+    { code: 'import * as wildcard from "wildcard"; cy.wait(wildcard.value)', parserOptions },
+    { code: 'import { NAME as OTHER_NAME } from "rename"; cy.wait(OTHER_NAME)', parserOptions },
+
+    // disable the eslint rule
+    {
+      code: `
+        cy.wait(100); // eslint-disable-line no-unnecessary-waiting
+      `,
+      parserOptions,
+    },
+    {
+      code: `
+        /* eslint-disable-next-line no-unnecessary-waiting */
+        cy.wait(100)
+      `,
+      parserOptions,
+    },
+    {
+      code: `
+        /* eslint-disable no-unnecessary-waiting */
+        cy.wait(100)
+        /* eslint-enable no-unnecessary-waiting */
+      `,
+      parserOptions,
+    },
+  ],
+
+  invalid: [
+    { code: 'cy.wait(0)', parserOptions, errors },
+    { code: 'cy.wait(100)', parserOptions, errors },
+    { code: 'cy.wait(5000)', parserOptions, errors },
+    { code: 'const someNumber=500; cy.wait(someNumber)', parserOptions, errors },
+    { code: 'function customWait (ms = 1) { cy.wait(ms) }', parserOptions, errors },
+    { code: 'const customWait = (ms = 1) => { cy.wait(ms) }', parserOptions, errors },
+
+    { code: 'cy.get(".some-element").wait(10)', parserOptions, errors },
+    { code: 'cy.get(".some-element").contains("foo").wait(10)', parserOptions, errors },
+    { code: 'const customWait = (ms = 1) => { cy.get(".some-element").wait(ms) }', parserOptions, errors },
+  ],
+})

--- a/tests-legacy/lib/rules/require-data-selectors.js
+++ b/tests-legacy/lib/rules/require-data-selectors.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const rule = require('../../../lib/rules/require-data-selectors')
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester()
+
+const errors = [{ messageId: 'unexpected' }]
+const parserOptions = { ecmaVersion: 6 }
+
+ruleTester.run('require-data-selectors', rule, {
+  valid: [
+    { code: 'cy.get(\'[data-cy=submit]\').click()', parserOptions },
+    { code: 'cy.get(\'[data-QA=submit]\')', parserOptions },
+    { code: 'cy.clock(5000)', parserOptions },
+    { code: 'cy.scrollTo(0, 10)', parserOptions },
+    { code: 'cy.tick(500)', parserOptions },
+    { code: 'cy.get(\`[data-cy=${1}]\`)', parserOptions }, // eslint-disable-line no-useless-escape
+    { code: 'cy.get("@my-alias")', parserOptions, errors },
+    { code: 'cy.get(`@my-alias`)', parserOptions, errors },
+  ],
+
+  invalid: [
+    { code: 'cy.get(\'[daedta-cy=submit]\').click()', parserOptions, errors },
+    { code: 'cy.get(\'[d-cy=submit]\')', parserOptions, errors },
+    { code: 'cy.get(".btn-large").click()', parserOptions, errors },
+    { code: 'cy.get(".btn-.large").click()', parserOptions, errors },
+    { code: 'cy.get(".a")', parserOptions, errors },
+    { code: 'cy.get(\`[daedta-cy=${1}]\`)', parserOptions, errors }, // eslint-disable-line no-useless-escape
+  ],
+})

--- a/tests-legacy/lib/rules/unsafe-to-chain-command.js
+++ b/tests-legacy/lib/rules/unsafe-to-chain-command.js
@@ -1,0 +1,56 @@
+'use strict'
+
+const rule = require('../../../lib/rules/unsafe-to-chain-command')
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester()
+
+const errors = [{ messageId: 'unexpected' }]
+const parserOptions = { ecmaVersion: 6 }
+
+ruleTester.run('action-ends-chain', rule, {
+  valid: [
+    {
+      code: 'cy.get("new-todo").type("todo A{enter}"); cy.get("new-todo").type("todo B{enter}"); cy.get("new-todo").should("have.class", "active");',
+      parserOptions,
+    },
+    {
+      code: 'cy.focused().should("be.visible");',
+      parserOptions,
+    },
+    {
+      code: 'cy.submitBtn().click();',
+      parserOptions,
+    },
+  ],
+
+  invalid: [
+    {
+      code: 'cy.get("new-todo").type("todo A{enter}").should("have.class", "active");',
+      parserOptions,
+      errors,
+    },
+    {
+      code: 'cy.get("new-todo").type("todo A{enter}").type("todo B{enter}");',
+      parserOptions,
+      errors,
+    },
+    {
+      code: 'cy.get("new-todo").focus().should("have.class", "active");',
+      parserOptions,
+      errors,
+    },
+    {
+      code: 'cy.get("new-todo").customType("todo A{enter}").customClick();',
+      parserOptions,
+      errors,
+      options: [{ methods: ['customType', 'customClick'] }],
+    },
+    {
+      code: 'cy.get("new-todo").customPress("Enter").customScroll();',
+      parserOptions,
+      errors,
+      options: [{ methods: [/customPress/, /customScroll/] }],
+    },
+  ],
+})


### PR DESCRIPTION
## Situation

Tests in the [tests/lib/rules](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/tests/lib/rules) which run internally under ESLint `7.x` and `8.x` are not compatible with ESLint `9.x`.

The guide [Migrate to 9.0 > FlatRuleTester is now RuleTester](https://eslint.org/docs/latest/use/migrate-to-9.0.0#flat-rule-tester) explains:

> As announced in our [blog post](https://eslint.org/blog/2023/10/flat-config-rollout-plans/), the temporary FlatRuleTester class has been renamed to RuleTester, while the RuleTester class from v8.x has been removed. Additionally, the FlatRuleTester export from eslint/use-at-your-own-risk has been removed.

This is a breaking change for the tests.

## Goal

The enhancement goal is to be able to test the repo rules using each of the supported versions of ESLint: `7.x`, `8.x` and `9.x`.

## Migration steps

Achieving the goal requires separating the tests into a legacy copy, for use with the `RuleTester` class of ESLint `7.x` and `8.x`, and another copy which will be migrated to use the `RuleTester` of ESLint `9.x`.

The migration is done in two steps:

1. Create the legacy copy of tests, a script to use this copy and a modification to the CircleCI workflow.
2. Modify the current copy of tests for compatibility with the new `RuleTester` class in ESLint `9.x`.

## Changes

This PR deals with creating the legacy copy.

A follow-on PR will take care of the second step of migrating tests to run under to ESLint `9.x`.

1. Copy `tests` to `tests-legacy`
2. Create a `jest.config-legacy.js`
3. Create a `test:legacy` script
4. Modify `circle.yml` to test ESLint `7` and `8` with `test-legacy`

Note that the original [tests/lib/rules](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/tests/lib/rules) directory is temporarily unused in this PR.

## References

- [Testing rules with flat config and the RuleTester class](https://eslint.org/blog/2022/08/new-config-system-part-3/#testing-rules-with-flat-config-and-the-ruletester-class)
- [FlatRuleTester is now RuleTester](https://eslint.org/docs/latest/use/migrate-to-9.0.0#flat-rule-tester)
- [v9 > RuleTester](https://eslint.org/docs/latest/integrate/nodejs-api#ruletester)

## Verification

Ubuntu `22.04.4` LTS, Node.js `v20.12.2` LTS and on
Windows 11, Node.js `v20.12.2`

```shell
npm ci
npm install eslint@7 --force
npm run test:legacy
npm install eslint@8
npm run test:legacy
```

At this point, ESLint 9 cannot be tested and would result in multiple errors. The resolution is left for a follow-on PR.
