### PR TITLE
chore: migrate to RuleTester v9

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,11 +7,13 @@ workflows:
       - lint
       - test-v7
       - test-v8
+      - test-v9
       - release:
           requires:
             - lint
             - test-v7
             - test-v8
+            - test-v9
           filters:
             branches:
               only:
@@ -71,6 +73,24 @@ jobs:
       - run:
           name: Test ESLint 8
           command: npm run test:legacy
+
+  test-v9:
+    docker:
+      - image: cimg/node:20.12.2
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: npm ci
+      - run:
+          name: Install ESLint 9
+          command: npm install eslint@9
+      - run:
+          name: Show ESLint version
+          command: npx eslint --version
+      - run:
+          name: Test ESLint 9
+          command: npm test
 
   release:
     docker:

--- a/tests/lib/rules/assertion-before-screenshot.js
+++ b/tests/lib/rules/assertion-before-screenshot.js
@@ -6,30 +6,29 @@ const RuleTester = require('eslint').RuleTester
 const ruleTester = new RuleTester()
 
 const errors = [{ messageId: 'unexpected' }]
-const parserOptions = { ecmaVersion: 6 }
 
 ruleTester.run('assertion-before-screenshot', rule, {
   valid: [
-    { code: 'cy.get(".some-element"); cy.screenshot();', parserOptions },
-    { code: 'cy.get(".some-element").should("exist").screenshot();', parserOptions },
-    { code: 'cy.get(".some-element").should("exist").screenshot().click()', parserOptions, errors },
-    { code: 'cy.get(".some-element").should("exist"); if(true) cy.screenshot();', parserOptions },
-    { code: 'if(true) { cy.get(".some-element").should("exist"); cy.screenshot(); }', parserOptions },
-    { code: 'cy.get(".some-element").should("exist"); if(true) { cy.screenshot(); }', parserOptions },
-    { code: 'const a = () => { cy.get(".some-element").should("exist"); cy.screenshot(); }', parserOptions, errors },
-    { code: 'cy.get(".some-element").should("exist").and("be.visible"); cy.screenshot();', parserOptions },
-    { code: 'cy.get(".some-element").contains("Text"); cy.screenshot();', parserOptions },
+    { code: 'cy.get(".some-element"); cy.screenshot();' },
+    { code: 'cy.get(".some-element").should("exist").screenshot();' },
+    { code: 'cy.get(".some-element").should("exist").screenshot().click()' },
+    { code: 'cy.get(".some-element").should("exist"); if(true) cy.screenshot();' },
+    { code: 'if(true) { cy.get(".some-element").should("exist"); cy.screenshot(); }' },
+    { code: 'cy.get(".some-element").should("exist"); if(true) { cy.screenshot(); }' },
+    { code: 'const a = () => { cy.get(".some-element").should("exist"); cy.screenshot(); }' },
+    { code: 'cy.get(".some-element").should("exist").and("be.visible"); cy.screenshot();' },
+    { code: 'cy.get(".some-element").contains("Text"); cy.screenshot();' },
   ],
 
   invalid: [
-    { code: 'cy.screenshot()', parserOptions, errors },
-    { code: 'cy.visit("somepage"); cy.screenshot();', parserOptions, errors },
-    { code: 'cy.custom(); cy.screenshot()', parserOptions, errors },
-    { code: 'cy.get(".some-element").click(); cy.screenshot()', parserOptions, errors },
-    { code: 'cy.get(".some-element").click().screenshot()', parserOptions, errors },
-    { code: 'if(true) { cy.get(".some-element").click(); cy.screenshot(); }', parserOptions, errors },
-    { code: 'cy.get(".some-element").click(); if(true) { cy.screenshot(); }', parserOptions, errors },
-    { code: 'cy.get(".some-element"); function a() { cy.screenshot(); }', parserOptions, errors },
-    { code: 'cy.get(".some-element"); const a = () => { cy.screenshot(); }', parserOptions, errors },
+    { code: 'cy.screenshot()', errors },
+    { code: 'cy.visit("somepage"); cy.screenshot();', errors },
+    { code: 'cy.custom(); cy.screenshot()', errors },
+    { code: 'cy.get(".some-element").click(); cy.screenshot()', errors },
+    { code: 'cy.get(".some-element").click().screenshot()', errors },
+    { code: 'if(true) { cy.get(".some-element").click(); cy.screenshot(); }', errors },
+    { code: 'cy.get(".some-element").click(); if(true) { cy.screenshot(); }', errors },
+    { code: 'cy.get(".some-element"); function a() { cy.screenshot(); }', errors },
+    { code: 'cy.get(".some-element"); const a = () => { cy.screenshot(); }', errors },
   ],
 })

--- a/tests/lib/rules/no-assigning-return-values.js
+++ b/tests/lib/rules/no-assigning-return-values.js
@@ -6,33 +6,32 @@ const RuleTester = require('eslint').RuleTester
 const ruleTester = new RuleTester()
 
 const errors = [{ messageId: 'unexpected' }]
-const parserOptions = { ecmaVersion: 6 }
 
 ruleTester.run('no-assigning-return-values', rule, {
   valid: [
-    { code: 'var foo = true;', parserOptions },
-    { code: 'let foo = true;', parserOptions },
-    { code: 'const foo = true;', parserOptions },
-    { code: 'const foo = bar();', parserOptions },
-    { code: 'const foo = bar().baz();', parserOptions },
-    { code: 'const spy = cy.spy();', parserOptions },
-    { code: 'const spy = cy.spy().as();', parserOptions },
-    { code: 'const stub = cy.stub();', parserOptions },
-    { code: 'const result = cy.now();', parserOptions },
-    { code: 'const state = cy.state();', parserOptions },
-    { code: 'cy.get("foo");', parserOptions },
-    { code: 'cy.contains("foo").click();', parserOptions },
+    { code: 'var foo = true;' },
+    { code: 'let foo = true;' },
+    { code: 'const foo = true;' },
+    { code: 'const foo = bar();' },
+    { code: 'const foo = bar().baz();' },
+    { code: 'const spy = cy.spy();' },
+    { code: 'const spy = cy.spy().as();' },
+    { code: 'const stub = cy.stub();' },
+    { code: 'const result = cy.now();' },
+    { code: 'const state = cy.state();' },
+    { code: 'cy.get("foo");' },
+    { code: 'cy.contains("foo").click();' },
   ],
 
   invalid: [
-    { code: 'let a = cy.get("foo")', parserOptions, errors },
-    { code: 'const a = cy.get("foo")', parserOptions, errors },
-    { code: 'var a = cy.get("foo")', parserOptions, errors },
+    { code: 'let a = cy.get("foo")', errors },
+    { code: 'const a = cy.get("foo")', errors },
+    { code: 'var a = cy.get("foo")', errors },
 
-    { code: 'let a = cy.contains("foo")', parserOptions, errors },
-    { code: 'let a = cy.window()', parserOptions, errors },
-    { code: 'let a = cy.wait("@something")', parserOptions, errors },
+    { code: 'let a = cy.contains("foo")', errors },
+    { code: 'let a = cy.window()', errors },
+    { code: 'let a = cy.wait("@something")', errors },
 
-    { code: 'let a = cy.contains("foo").click()', parserOptions, errors },
+    { code: 'let a = cy.contains("foo").click()', errors },
   ],
 })

--- a/tests/lib/rules/no-async-before.js
+++ b/tests/lib/rules/no-async-before.js
@@ -6,20 +6,18 @@ const RuleTester = require('eslint').RuleTester
 const ruleTester = new RuleTester()
 
 const errors = [{ messageId: 'unexpected' }]
-// async functions are an ES2017 feature
-const parserOptions = { ecmaVersion: 8 }
 
 ruleTester.run('no-async-before', rule, {
   valid: [
-    { code: 'before(\'a before case\', () => { cy.get(\'.someClass\'); })', parserOptions },
-    { code: 'before(\'a before case\', async () => { await somethingAsync(); })', parserOptions },
-    { code: 'async function nonTestFn () { return await somethingAsync(); }', parserOptions },
-    { code: 'const nonTestArrowFn = async () => { await somethingAsync(); }', parserOptions },
+    { code: 'before(\'a before case\', () => { cy.get(\'.someClass\'); })' },
+    { code: 'before(\'a before case\', async () => { await somethingAsync(); })' },
+    { code: 'async function nonTestFn () { return await somethingAsync(); }' },
+    { code: 'const nonTestArrowFn = async () => { await somethingAsync(); }' },
   ],
   invalid: [
-    { code: 'before(\'a test case\', async () => { cy.get(\'.someClass\'); })', parserOptions, errors },
-    { code: 'beforeEach(\'a test case\', async () => { cy.get(\'.someClass\'); })', parserOptions, errors },
-    { code: 'before(\'a test case\', async function () { cy.get(\'.someClass\'); })', parserOptions, errors },
-    { code: 'beforeEach(\'a test case\', async function () { cy.get(\'.someClass\'); })', parserOptions, errors },
+    { code: 'before(\'a test case\', async () => { cy.get(\'.someClass\'); })', errors },
+    { code: 'beforeEach(\'a test case\', async () => { cy.get(\'.someClass\'); })', errors },
+    { code: 'before(\'a test case\', async function () { cy.get(\'.someClass\'); })', errors },
+    { code: 'beforeEach(\'a test case\', async function () { cy.get(\'.someClass\'); })', errors },
   ],
 })

--- a/tests/lib/rules/no-async-tests.js
+++ b/tests/lib/rules/no-async-tests.js
@@ -6,20 +6,18 @@ const RuleTester = require('eslint').RuleTester
 const ruleTester = new RuleTester()
 
 const errors = [{ messageId: 'unexpected' }]
-// async functions are an ES2017 feature
-const parserOptions = { ecmaVersion: 8 }
 
 ruleTester.run('no-async-tests', rule, {
   valid: [
-    { code: 'it(\'a test case\', () => { cy.get(\'.someClass\'); })', parserOptions },
-    { code: 'it(\'a test case\', async () => { await somethingAsync(); })', parserOptions },
-    { code: 'async function nonTestFn () { return await somethingAsync(); }', parserOptions },
-    { code: 'const nonTestArrowFn = async () => { await somethingAsync(); }', parserOptions },
+    { code: 'it(\'a test case\', () => { cy.get(\'.someClass\'); })' },
+    { code: 'it(\'a test case\', async () => { await somethingAsync(); })' },
+    { code: 'async function nonTestFn () { return await somethingAsync(); }' },
+    { code: 'const nonTestArrowFn = async () => { await somethingAsync(); }' },
   ],
   invalid: [
-    { code: 'it(\'a test case\', async () => { cy.get(\'.someClass\'); })', parserOptions, errors },
-    { code: 'test(\'a test case\', async () => { cy.get(\'.someClass\'); })', parserOptions, errors },
-    { code: 'it(\'a test case\', async function () { cy.get(\'.someClass\'); })', parserOptions, errors },
-    { code: 'test(\'a test case\', async function () { cy.get(\'.someClass\'); })', parserOptions, errors },
+    { code: 'it(\'a test case\', async () => { cy.get(\'.someClass\'); })', errors },
+    { code: 'test(\'a test case\', async () => { cy.get(\'.someClass\'); })', errors },
+    { code: 'it(\'a test case\', async function () { cy.get(\'.someClass\'); })', errors },
+    { code: 'test(\'a test case\', async function () { cy.get(\'.someClass\'); })', errors },
   ],
 })

--- a/tests/lib/rules/no-force.js
+++ b/tests/lib/rules/no-force.js
@@ -1,49 +1,39 @@
 'use strict'
 
-//------------------------------------------------------------------------------
-// Requirements
-//------------------------------------------------------------------------------
-
 const rule = require('../../../lib/rules/no-force')
-
 const RuleTester = require('eslint').RuleTester
 
+const ruleTester = new RuleTester()
+
 const errors = [{ messageId: 'unexpected' }]
-const parserOptions = { ecmaVersion: 2018 }
-
-//------------------------------------------------------------------------------
-// Tests
-//------------------------------------------------------------------------------
-
-let ruleTester = new RuleTester()
 
 ruleTester.run('no-force', rule, {
 
   valid: [
-    { code: `cy.get('button').click()`, parserOptions },
-    { code: `cy.get('button').click({multiple: true})`, parserOptions },
-    { code: `cy.get('button').dblclick()`, parserOptions },
-    { code: `cy.get('input').type('somth')`, parserOptions },
-    { code: `cy.get('input').type('somth', {anyoption: true})`, parserOptions },
-    { code: `cy.get('input').trigger('click', {anyoption: true})`, parserOptions },
-    { code: `cy.get('input').rightclick({anyoption: true})`, parserOptions },
-    { code: `cy.get('input').check()`, parserOptions },
-    { code: `cy.get('input').select()`, parserOptions },
-    { code: `cy.get('input').focus()`, parserOptions },
-    { code: `cy.document().trigger("keydown", { ...event })`, parserOptions },
+    { code: `cy.get('button').click()` },
+    { code: `cy.get('button').click({multiple: true})` },
+    { code: `cy.get('button').dblclick()` },
+    { code: `cy.get('input').type('somth')` },
+    { code: `cy.get('input').type('somth', {anyoption: true})` },
+    { code: `cy.get('input').trigger('click', {anyoption: true})` },
+    { code: `cy.get('input').rightclick({anyoption: true})` },
+    { code: `cy.get('input').check()` },
+    { code: `cy.get('input').select()` },
+    { code: `cy.get('input').focus()` },
+    { code: `cy.document().trigger("keydown", { ...event })` },
   ],
 
   invalid: [
-    { code: `cy.get('button').click({force: true})`, parserOptions, errors },
-    { code: `cy.get('button').dblclick({force: true})`, parserOptions, errors },
-    { code: `cy.get('input').type('somth', {force: true})`, parserOptions, errors },
-    { code: `cy.get('div').find('.foo').type('somth', {force: true})`, parserOptions, errors },
-    { code: `cy.get('div').find('.foo').find('.bar').click({force: true})`, parserOptions, errors },
-    { code: `cy.get('div').find('.foo').find('.bar').trigger('change', {force: true})`, parserOptions, errors },
-    { code: `cy.get('input').trigger('click', {force: true})`, parserOptions, errors },
-    { code: `cy.get('input').rightclick({force: true})`, parserOptions, errors },
-    { code: `cy.get('input').check({force: true})`, parserOptions, errors },
-    { code: `cy.get('input').select({force: true})`, parserOptions, errors },
-    { code: `cy.get('input').focus({force: true})`, parserOptions, errors },
+    { code: `cy.get('button').click({force: true})`, errors },
+    { code: `cy.get('button').dblclick({force: true})`, errors },
+    { code: `cy.get('input').type('somth', {force: true})`, errors },
+    { code: `cy.get('div').find('.foo').type('somth', {force: true})`, errors },
+    { code: `cy.get('div').find('.foo').find('.bar').click({force: true})`, errors },
+    { code: `cy.get('div').find('.foo').find('.bar').trigger('change', {force: true})`, errors },
+    { code: `cy.get('input').trigger('click', {force: true})`, errors },
+    { code: `cy.get('input').rightclick({force: true})`, errors },
+    { code: `cy.get('input').check({force: true})`, errors },
+    { code: `cy.get('input').select({force: true})`, errors },
+    { code: `cy.get('input').focus({force: true})`, errors },
   ],
 })

--- a/tests/lib/rules/no-pause.js
+++ b/tests/lib/rules/no-pause.js
@@ -1,37 +1,23 @@
 'use strict'
 
-//------------------------------------------------------------------------------
-// Requirements
-//------------------------------------------------------------------------------
-
 const rule = require('../../../lib/rules/no-pause')
-
 const RuleTester = require('eslint').RuleTester
 
-const errors = [{ messageId: 'unexpected' }]
-const parserOptions = { ecmaVersion: 2018 }
-
-//------------------------------------------------------------------------------
-// Tests
-//------------------------------------------------------------------------------
-
 const ruleTester = new RuleTester()
+
+const errors = [{ messageId: 'unexpected' }]
 
 ruleTester.run('no-pause', rule, {
 
   valid: [
-    { code: `pause()`, parserOptions },
-    { code: `cy.get('button').dblclick()`, parserOptions },
+    { code: `pause()` },
+    { code: `cy.get('button').dblclick()` },
   ],
-  
+
   invalid: [
-    { code: `cy.pause()`, parserOptions, errors },
-    { code: `cy.pause({ log: false })`, parserOptions, errors },
-    { code: `cy.get('button').pause()`, parserOptions, errors },
-    { 
-      code: `cy.get('a').should('have.attr', 'href').and('match', /dashboard/).pause()`, 
-      parserOptions, 
-      errors 
-    }
+    { code: `cy.pause()`, errors },
+    { code: `cy.pause({ log: false })`, errors },
+    { code: `cy.get('button').pause()`, errors },
+    { code: `cy.get('a').should('have.attr', 'href').and('match', /dashboard/).pause()`, errors }
   ],
 })

--- a/tests/lib/rules/no-unnecessary-waiting.js
+++ b/tests/lib/rules/no-unnecessary-waiting.js
@@ -6,66 +6,42 @@ const RuleTester = require('eslint').RuleTester
 const ruleTester = new RuleTester()
 
 const errors = [{ messageId: 'unexpected' }]
-const parserOptions = { ecmaVersion: 6, sourceType: 'module' }
 
 ruleTester.run('no-unnecessary-waiting', rule, {
   valid: [
-    { code: 'foo.wait(10)', parserOptions },
+    { code: 'foo.wait(10)' },
 
-    { code: 'cy.wait("@someRequest")', parserOptions },
-    { code: 'cy.wait("@someRequest", { log: false })', parserOptions },
-    { code: 'cy.wait("@someRequest").then((xhr) => xhr)', parserOptions },
-    { code: 'cy.wait(["@someRequest", "@anotherRequest"])', parserOptions },
+    { code: 'cy.wait("@someRequest")' },
+    { code: 'cy.wait("@someRequest", { log: false })' },
+    { code: 'cy.wait("@someRequest").then((xhr) => xhr)' },
+    { code: 'cy.wait(["@someRequest", "@anotherRequest"])' },
 
-    { code: 'cy.clock(5000)', parserOptions },
-    { code: 'cy.scrollTo(0, 10)', parserOptions },
-    { code: 'cy.tick(500)', parserOptions },
+    { code: 'cy.clock(5000)' },
+    { code: 'cy.scrollTo(0, 10)' },
+    { code: 'cy.tick(500)' },
 
-    { code: 'const someRequest="@someRequest"; cy.wait(someRequest)', parserOptions, errors },
-    { code: 'function customWait (alias = "@someRequest") { cy.wait(alias) }', parserOptions, errors },
-    { code: 'const customWait = (alias = "@someRequest") => { cy.wait(alias) }', parserOptions, errors },
-    { code: 'function customWait (ms) { cy.wait(ms) }', parserOptions, errors },
-    { code: 'const customWait = (ms) => { cy.wait(ms) }', parserOptions, errors },
+    { code: 'const someRequest="@someRequest"; cy.wait(someRequest)' },
+    { code: 'function customWait (alias = "@someRequest") { cy.wait(alias) }' },
+    { code: 'const customWait = (alias = "@someRequest") => { cy.wait(alias) }' },
+    { code: 'function customWait (ms) { cy.wait(ms) }' },
+    { code: 'const customWait = (ms) => { cy.wait(ms) }' },
 
-    { code: 'import BAR_BAZ from "bar-baz"; cy.wait(BAR_BAZ)', parserOptions },
-    { code: 'import { FOO_BAR } from "foo-bar"; cy.wait(FOO_BAR)', parserOptions },
-    { code: 'import * as wildcard from "wildcard"; cy.wait(wildcard.value)', parserOptions },
-    { code: 'import { NAME as OTHER_NAME } from "rename"; cy.wait(OTHER_NAME)', parserOptions },
-
-    // disable the eslint rule
-    {
-      code: `
-        cy.wait(100); // eslint-disable-line no-unnecessary-waiting
-      `,
-      parserOptions,
-    },
-    {
-      code: `
-        /* eslint-disable-next-line no-unnecessary-waiting */
-        cy.wait(100)
-      `,
-      parserOptions,
-    },
-    {
-      code: `
-        /* eslint-disable no-unnecessary-waiting */
-        cy.wait(100)
-        /* eslint-enable no-unnecessary-waiting */
-      `,
-      parserOptions,
-    },
+    { code: 'import BAR_BAZ from "bar-baz"; cy.wait(BAR_BAZ)' },
+    { code: 'import { FOO_BAR } from "foo-bar"; cy.wait(FOO_BAR)' },
+    { code: 'import * as wildcard from "wildcard"; cy.wait(wildcard.value)' },
+    { code: 'import { NAME as OTHER_NAME } from "rename"; cy.wait(OTHER_NAME)' },
   ],
 
   invalid: [
-    { code: 'cy.wait(0)', parserOptions, errors },
-    { code: 'cy.wait(100)', parserOptions, errors },
-    { code: 'cy.wait(5000)', parserOptions, errors },
-    { code: 'const someNumber=500; cy.wait(someNumber)', parserOptions, errors },
-    { code: 'function customWait (ms = 1) { cy.wait(ms) }', parserOptions, errors },
-    { code: 'const customWait = (ms = 1) => { cy.wait(ms) }', parserOptions, errors },
+    { code: 'cy.wait(0)', errors },
+    { code: 'cy.wait(100)', errors },
+    { code: 'cy.wait(5000)', errors },
+    { code: 'const someNumber=500; cy.wait(someNumber)', errors },
+    { code: 'function customWait (ms = 1) { cy.wait(ms) }', errors },
+    { code: 'const customWait = (ms = 1) => { cy.wait(ms) }', errors },
 
-    { code: 'cy.get(".some-element").wait(10)', parserOptions, errors },
-    { code: 'cy.get(".some-element").contains("foo").wait(10)', parserOptions, errors },
-    { code: 'const customWait = (ms = 1) => { cy.get(".some-element").wait(ms) }', parserOptions, errors },
+    { code: 'cy.get(".some-element").wait(10)', errors },
+    { code: 'cy.get(".some-element").contains("foo").wait(10)', errors },
+    { code: 'const customWait = (ms = 1) => { cy.get(".some-element").wait(ms) }', errors },
   ],
 })

--- a/tests/lib/rules/require-data-selectors.js
+++ b/tests/lib/rules/require-data-selectors.js
@@ -6,26 +6,25 @@ const RuleTester = require('eslint').RuleTester
 const ruleTester = new RuleTester()
 
 const errors = [{ messageId: 'unexpected' }]
-const parserOptions = { ecmaVersion: 6 }
 
 ruleTester.run('require-data-selectors', rule, {
   valid: [
-    { code: 'cy.get(\'[data-cy=submit]\').click()', parserOptions },
-    { code: 'cy.get(\'[data-QA=submit]\')', parserOptions },
-    { code: 'cy.clock(5000)', parserOptions },
-    { code: 'cy.scrollTo(0, 10)', parserOptions },
-    { code: 'cy.tick(500)', parserOptions },
-    { code: 'cy.get(\`[data-cy=${1}]\`)', parserOptions }, // eslint-disable-line no-useless-escape
-    { code: 'cy.get("@my-alias")', parserOptions, errors },
-    { code: 'cy.get(`@my-alias`)', parserOptions, errors },
+    { code: 'cy.get(\'[data-cy=submit]\').click()' },
+    { code: 'cy.get(\'[data-QA=submit]\')' },
+    { code: 'cy.clock(5000)' },
+    { code: 'cy.scrollTo(0, 10)' },
+    { code: 'cy.tick(500)' },
+    { code: 'cy.get(\`[data-cy=${1}]\`)' }, // eslint-disable-line no-useless-escape
+    { code: 'cy.get("@my-alias")' },
+    { code: 'cy.get(`@my-alias`)' },
   ],
 
   invalid: [
-    { code: 'cy.get(\'[daedta-cy=submit]\').click()', parserOptions, errors },
-    { code: 'cy.get(\'[d-cy=submit]\')', parserOptions, errors },
-    { code: 'cy.get(".btn-large").click()', parserOptions, errors },
-    { code: 'cy.get(".btn-.large").click()', parserOptions, errors },
-    { code: 'cy.get(".a")', parserOptions, errors },
-    { code: 'cy.get(\`[daedta-cy=${1}]\`)', parserOptions, errors }, // eslint-disable-line no-useless-escape
+    { code: 'cy.get(\'[daedta-cy=submit]\').click()', errors },
+    { code: 'cy.get(\'[d-cy=submit]\')', errors },
+    { code: 'cy.get(".btn-large").click()', errors },
+    { code: 'cy.get(".btn-.large").click()', errors },
+    { code: 'cy.get(".a")', errors },
+    { code: 'cy.get(\`[daedta-cy=${1}]\`)', errors }, // eslint-disable-line no-useless-escape
   ],
 })

--- a/tests/lib/rules/unsafe-to-chain-command.js
+++ b/tests/lib/rules/unsafe-to-chain-command.js
@@ -6,51 +6,29 @@ const RuleTester = require('eslint').RuleTester
 const ruleTester = new RuleTester()
 
 const errors = [{ messageId: 'unexpected' }]
-const parserOptions = { ecmaVersion: 6 }
 
 ruleTester.run('action-ends-chain', rule, {
   valid: [
     {
-      code: 'cy.get("new-todo").type("todo A{enter}"); cy.get("new-todo").type("todo B{enter}"); cy.get("new-todo").should("have.class", "active");',
-      parserOptions,
+      code: 'cy.get("new-todo").type("todo A{enter}"); cy.get("new-todo").type("todo B{enter}"); cy.get("new-todo").should("have.class", "active");'
     },
-    {
-      code: 'cy.focused().should("be.visible");',
-      parserOptions,
-    },
-    {
-      code: 'cy.submitBtn().click();',
-      parserOptions,
-    },
+    { code: 'cy.focused().should("be.visible");' },
+    { code: 'cy.submitBtn().click();' },
   ],
 
   invalid: [
-    {
-      code: 'cy.get("new-todo").type("todo A{enter}").should("have.class", "active");',
-      parserOptions,
-      errors,
-    },
-    {
-      code: 'cy.get("new-todo").type("todo A{enter}").type("todo B{enter}");',
-      parserOptions,
-      errors,
-    },
-    {
-      code: 'cy.get("new-todo").focus().should("have.class", "active");',
-      parserOptions,
-      errors,
-    },
+    { code: 'cy.get("new-todo").type("todo A{enter}").should("have.class", "active");', errors },
+    { code: 'cy.get("new-todo").type("todo A{enter}").type("todo B{enter}");', errors },
+    { code: 'cy.get("new-todo").focus().should("have.class", "active");', errors },
     {
       code: 'cy.get("new-todo").customType("todo A{enter}").customClick();',
-      parserOptions,
       errors,
       options: [{ methods: ['customType', 'customClick'] }],
     },
     {
       code: 'cy.get("new-todo").customPress("Enter").customScroll();',
-      parserOptions,
       errors,
-      options: [{ methods: [/customPress/, /customScroll/] }],
+      options: [{ methods: ['customPress', 'customScroll'] }],
     },
   ],
 })


### PR DESCRIPTION
- Part 2: Following on from PR https://github.com/cypress-io/eslint-plugin-cypress/pull/205

## Situation

Tests in the [tests/lib/rules](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/tests/lib/rules) which run internally under ESLint `7.x` and `8.x` are not compatible with ESLint `9.x`.

The guide [Migrate to 9.0 > FlatRuleTester is now RuleTester](https://eslint.org/docs/latest/use/migrate-to-9.0.0#flat-rule-tester) explains:

> As announced in our [blog post](https://eslint.org/blog/2023/10/flat-config-rollout-plans/), the temporary FlatRuleTester class has been renamed to RuleTester, while the RuleTester class from v8.x has been removed. Additionally, the FlatRuleTester export from eslint/use-at-your-own-risk has been removed.

This is a breaking change for the tests.

## Goal

The enhancement goal is to be able to test the repo rules using each of the supported versions of ESLint: `7.x`, `8.x` and `9.x`.

## Migration steps

Achieving the goal requires separating the tests into a legacy copy, for use with the `RuleTester` class of ESLint `7.x` and `8.x`, and another copy which will be migrated to use the `RuleTester` of ESLint `9.x`.

The migration is done in two steps:

1. Create the legacy copy of tests, a script to use this copy and a modification to the CircleCI workflow. Done in PR https://github.com/cypress-io/eslint-plugin-cypress/pull/205.
2. Modify the current copy of tests for compatibility with the new `RuleTester` class in ESLint `9.x`. (This PR.)

## Changes

This PR deals with the second step of modifying the current copy of tests for compatibility with the new `RuleTester` class in ESLint `9.x`.

For all [tests/lib/rules](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/tests/lib/rules) `*.js` test files:

1. harmonize tests to use the code block:
   ```js
   const RuleTester = require('eslint').RuleTester
   const ruleTester = new RuleTester()
   ```
   according to the [v9 > RuleTester](https://eslint.org/docs/latest/integrate/nodejs-api#ruletester) documentation.
2. Harmonize other formating.
3. ~~Change~~ Remove unnecessary `parserOptions` ~~to `languageOptions`~~. Edit: See https://github.com/cypress-io/eslint-plugin-cypress/pull/207#issuecomment-2100280450
4. For [tests/lib/rules/no-unnecessary-waiting.js](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/tests/lib/rules/no-unnecessary-waiting.js) remove the section which attempts to test disabling the rule. This is not compatible with the `v9` `RuleTester` and it is attempting to test a function of ESLint rather than the rule itself.
5. For [tests/lib/rules/unsafe-to-chain-command.js](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/tests/lib/rules/unsafe-to-chain-command.js) modify an incompatible option syntax in one rule.

For the CircleCI workflow
1. Create a new test in CircleCI for ESLint `9.x` to use the modified current tests.

## References

- [Testing rules with flat config and the RuleTester class](https://eslint.org/blog/2022/08/new-config-system-part-3/#testing-rules-with-flat-config-and-the-ruletester-class)
- [FlatRuleTester is now RuleTester](https://eslint.org/docs/latest/use/migrate-to-9.0.0#flat-rule-tester)
- [v9 > RuleTester](https://eslint.org/docs/latest/integrate/nodejs-api#ruletester)
