### PR TITLE
docs: rework contributor instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,15 +2,49 @@
 
 Thanks for taking the time to contribute! :smile:
 
-To add a new rule:
-  * Fork and clone this repository
-  * Generate a new rule (a [yeoman generator](https://github.com/eslint/generator-eslint) is available)
-  * Write test scenarios then implement logic
-  * Describe the rule in the generated `docs` file
-  * Run `npm test` to run [Jest](https://jestjs.io/) or
-  * Run `npm start` to run [Jest](https://jestjs.io/) in [watchAll](https://jestjs.io/docs/cli#--watchall) mode where it remains active and reruns when source changes are made
-  * Make sure all tests are passing
-  * Add the rule to the [README](README.md) file
-  * Create a PR
+## Preparation
 
-Use the following commit message conventions: https://github.com/semantic-release/semantic-release#commit-message-format
+* Fork and clone this repository
+* Branch from the default `master` branch using a descriptive new branch name
+* Install dependencies with `npm ci`
+
+## Rule references
+
+* Refer to the [ESLint documentation](https://eslint.org/docs/latest/) and the [Custom Rules](https://eslint.org/docs/latest/extend/custom-rules) page
+
+## New rule
+
+To add a new rule:
+
+* Follow the instructions in the ESLint [generator-eslint](https://www.npmjs.com/package/generator-eslint) documentation to install [Yeoman](https://www.npmjs.com/package/yo) and the generator
+* Run the new rule generator `yo eslint:rule` and answer the questions
+  - select "ESLint Plugin"
+  - for "Type a short description of this rule" provide text which starts with one of "enforce", "require" or "disallow" (all lower case)
+* Yeoman creates three boilerplate files:
+  - `docs/rules/<rule-id>.md`
+  - `lib/rules/<rule-id>.js`
+  - `test/rules/<rule-id>.js`
+* Run `npm run lint-fix`
+* Address the linting errors by editing `lib/rules/<rule-id>.js`
+  - Add a `meta.messages` property (see [MessageIds](https://eslint.org/docs/latest/extend/custom-rules#messageids))
+  - Select the appropriate `meta.type` property using `problem`, `suggestion`, or `layout`
+* Complete the new rule by adding content to the three files previously created
+* Run `eslint-doc-generator` to generate automated documentation sections (see [Document generation](#document-generation) below)
+* Review documentation changes
+* Run `npm run lint`
+* Run `npm test` to run [Jest](https://jestjs.io/) (or run `npm start` to run [Jest](https://jestjs.io/) in [watchAll](https://jestjs.io/docs/cli#--watchall) mode where it remains active and reruns when source changes are made)
+* Make sure all tests are passing
+* Add the rule to [index.js](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/index.js)
+* Create a git commit with a commit message similar to: `feat: add rule <description>` (see [commit message conventions](https://github.com/semantic-release/semantic-release#commit-message-format))
+* Create a PR from your branch
+
+## Document generation
+
+This plugin uses the ESLint [eslint-doc-generator](https://www.npmjs.com/package/eslint-doc-generator) to generate consistent documentation.
+* Install with `npm install eslint-doc-generator -g`
+* Run `eslint-doc-generator` in the root directory of the plugin
+
+## Legacy tests
+
+* The directory [tests-legacy](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/tests-legacy) contains tests which are compatible with the legacy [ESLint v8 RuleTester](https://eslint.org/docs/v8.x/integrate/nodejs-api#ruletester) utility. It is not expected to add new rules to this set of tests.
+* The directory [tests](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/tests) is for tests compatible with the current [ESLint RuleTester](https://eslint.org/docs/latest/integrate/nodejs-api#ruletester).


### PR DESCRIPTION
## Details

The [CONTRIBUTING](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/CONTRIBUTING.md) document is reworked and expanded in detail.

## Corrections

- The following step was added to the instructions. The fact that this was missing has led to rules being published inactive in the past. (See history of [index.js](https://github.com/cypress-io/eslint-plugin-cypress/commits/master/index.js) listing multiple examples of this mistake over the years.)
  > Add the rule to [index.js](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/index.js)

## Additions

The following sections are added:

- Preparation
- Rule references
- New rule
- Document generation
- Legacy tests

Generally the level of detail has been increased.

### Document generation

The utility ESLint [eslint-doc-generator](https://www.npmjs.com/package/eslint-doc-generator) is introduced as an optional way to produce consistent documentation. It has already been used in:

- #197
- #198

and so the [README](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/README.md) and documents in the [docs/rules](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/docs/rules) directory are prepared to use [eslint-doc-generator](https://www.npmjs.com/package/eslint-doc-generator).

- There is a https://github.com/bmish/eslint-doc-generator/issues/525 in the current version, so it has been recommended to install it globally to avoid the warning. When this issue is resolved, which may take some time due to complex interdependencies, it could be added directly into the repo.

### Legacy tests

- The directory [tests-legacy](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/tests-legacy) added in PR https://github.com/cypress-io/eslint-plugin-cypress/pull/205 is explained.
