### PR TITLE
test: add property ordering rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,8 @@ export default [
       'eslint-plugin/require-meta-docs-url':
         ['error', { 'pattern': 'https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/{{name}}.md' }],
       'eslint-plugin/require-meta-docs-description': 'error',
+      'eslint-plugin/meta-property-ordering': 'error',
+      'eslint-plugin/test-case-property-ordering': 'error',
       'n/no-extraneous-require':
         ['error', { 'allowModules': ['jest-config'] }],
       'mocha/no-mocha-arrows': 'off',

--- a/tests-legacy/lib/rules/unsafe-to-chain-command.js
+++ b/tests-legacy/lib/rules/unsafe-to-chain-command.js
@@ -42,15 +42,15 @@ ruleTester.run('action-ends-chain', rule, {
     },
     {
       code: 'cy.get("new-todo").customType("todo A{enter}").customClick();',
+      options: [{ methods: ['customType', 'customClick'] }],
       parserOptions,
       errors,
-      options: [{ methods: ['customType', 'customClick'] }],
     },
     {
       code: 'cy.get("new-todo").customPress("Enter").customScroll();',
+      options: [{ methods: [/customPress/, /customScroll/] }],
       parserOptions,
       errors,
-      options: [{ methods: [/customPress/, /customScroll/] }],
     },
   ],
 })

--- a/tests/lib/rules/unsafe-to-chain-command.js
+++ b/tests/lib/rules/unsafe-to-chain-command.js
@@ -22,13 +22,13 @@ ruleTester.run('action-ends-chain', rule, {
     { code: 'cy.get("new-todo").focus().should("have.class", "active");', errors },
     {
       code: 'cy.get("new-todo").customType("todo A{enter}").customClick();',
-      errors,
       options: [{ methods: ['customType', 'customClick'] }],
+      errors,
     },
     {
       code: 'cy.get("new-todo").customPress("Enter").customScroll();',
-      errors,
       options: [{ methods: ['customPress', 'customScroll'] }],
+      errors,
     },
   ],
 })


### PR DESCRIPTION
## Situation

The [eslint-plugin-eslint-plugin](https://www.npmjs.com/package/eslint-plugin-eslint-plugin), for linting plugins, provides two rules to ensure consistent property ordering:

- [Enforce the order of meta properties (eslint-plugin/meta-property-ordering)](https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/HEAD/docs/rules/meta-property-ordering.md)
- [Require the properties of a test case to be placed in a consistent order (eslint-plugin/test-case-property-ordering)](https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/HEAD/docs/rules/test-case-property-ordering.md)

These rules are not part of the `flat/recommended` set of [eslint-plugin-eslint-plugin](https://www.npmjs.com/package/eslint-plugin-eslint-plugin) and are currently not applied. They are however beneficial for rule and test consistency.

## Change

- Apply the above two rules
- Fix non-compliance in
  - [tests-legacy/lib/rules/unsafe-to-chain-command.js](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/tests-legacy/lib/rules/unsafe-to-chain-command.js)
  - [tests/lib/rules/unsafe-to-chain-command.js](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/tests/lib/rules/unsafe-to-chain-command.js)