### PR TITLE
feat: add `name` to configs (for tooling)

### DIFF
--- a/lib/flat.js
+++ b/lib/flat.js
@@ -33,6 +33,7 @@ const commonLanguageOptions = {
 
 Object.assign(plugin.configs, {
   globals: {
+    name: 'cypress/globals',
     plugins: {
       cypress: plugin
     },
@@ -46,6 +47,7 @@ Object.assign(plugin.configs, {
 
 Object.assign(plugin.configs, {
   recommended: {
+    name: 'cypress/recommended',
     plugins: {
       cypress: plugin
     },


### PR DESCRIPTION
feat: add `name` to configs (for tooling)

ESLint [recommends](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-naming-conventions) a name for flat configs.

Tools like https://github.com/eslint/config-inspector can use this to indicate the source of rules.

I did not add it to the older, non-flat config because it will err there.