### PR TITLE
chore: correct package.json exports key indentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "An ESLint plugin for projects using Cypress",
   "main": "legacy.js",
   "exports": {
-      ".": "./legacy.js",
-      "./flat": "./lib/flat.js"
-    },
+    ".": "./legacy.js",
+    "./flat": "./lib/flat.js"
+  },
   "author": "Cypress-io",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
## Issue

Making changes to dependencies in `package.json` through npm now causes whitespace indentation changes to the file in the `exports` key.

## Change

Execute the following command to normalize `package.json`.

```shell
npm pkg fix
```

Since this is a whitespace change only, no new version release is triggered.

After this change, `npm install` has no more formatting side-effects.