### PR TITLE
docs: deprecate eslint v8

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ yarn add eslint-plugin-cypress --dev
 
 ## Deprecations
 
-The use of ESLint `v7` with `eslint-plugin-cypress` is deprecated and support will be removed in a future version of this plugin. ESLint `v7` reached end-of-life on Apr 9, 2022 and users are encouraged to migrate to ESLint `v9`. See [ESLint Version Support](https://eslint.org/version-support/) for ESLint's current release lines.
+The use of ESLint `v7` and `v8` with `eslint-plugin-cypress` is deprecated and support will be removed in a future version of this plugin. ESLint `v7` reached end-of-life on Apr 9, 2022 and ESLint `v8` reached end-of-life on Oct 5, 2024. Users are encouraged to migrate to ESLint `v9`. See [ESLint Version Support](https://eslint.org/version-support/) for ESLint's current release lines.
 
 ## Usage
 
-If you are using ESLint `v7` or `v8`, then add an `.eslintrc.json` file to the root directory of your Cypress project with the contents shown below. You can continue to use this format with ESLint `v9` if you set the `ESLINT_USE_FLAT_CONFIG` environment variable to `false` (see [ESLint v9 > Configuration Files (Deprecated)](https://eslint.org/docs/latest/use/configure/configuration-files-deprecated).
+If you are using ESLint `v7` or `v8`, then add an `.eslintrc.json` file to the root directory of your Cypress project with the contents shown below. You can continue to use this format with ESLint `v9` if you set the `ESLINT_USE_FLAT_CONFIG` environment variable to `false` (see [ESLint v9 > Configuration Files (Deprecated)](https://eslint.org/docs/latest/use/configure/configuration-files-deprecated)).
 
 ESLint `v9` uses a [Flat config file](https://eslint.org/docs/latest/use/configure/configuration-files) format with filename `eslint.config.*js` by default. Please refer to [additional Flat config installation and configuration details](FLAT-CONFIG.md). (You may also use this with ESLint `8.57.0`.)
 


### PR DESCRIPTION
## Issue

[ESLint v8.x end-of-life](https://eslint.org/version-support/) begins on Oct 5, 2024 (Edit: this is now in the past).

The [eslint-plugin-cypress](https://www.npmjs.com/package/eslint-plugin-cypress) plugin needs to withdraw support for ESLint v8 due to this status change.

## Change

Add deprecation information for ESLint v8 to existing section [README > Deprecations](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/README.md#deprecations) which already deprecates support for ESLint v7.

There are no technical changes to the plugin caused by the deprecation.