### PR TITLE
feat: minimum version eslint v9

### DIFF
--- a/FLAT-CONFIG.md
+++ b/FLAT-CONFIG.md
@@ -2,7 +2,7 @@
 
 This document supplements the [README](README.md) document and describes how to use the Cypress ESLint Plugin (`eslint-plugin-cypress`) in an ESLint flat config environment.
 
-Usage with ESLint `8.57.0` and ESLint `9.x` is described.
+Usage with ESLint `9.x` is described.
 
 ## Introduction
 
@@ -10,13 +10,11 @@ Usage with ESLint `8.57.0` and ESLint `9.x` is described.
 
 Previously, ESLint had announced in their blog post [Flat config rollout plans](https://eslint.org/blog/2023/10/flat-config-rollout-plans/) in October 2023 that flat config was planned to be the default in ESLint `v9.0.0` and that the eslintrc configuration system is planned to be removed in the future ESLint `v10.0.0`.
 
-Cypress ESLint Plugin (`eslint-plugin-cypress`) in release [3.2.0](https://github.com/cypress-io/eslint-plugin-cypress/releases/tag/v3.2.0) offered the first support of ESLint `9.x` flat config files using the [Backwards compatibility utility](https://eslint.org/blog/2022/08/new-config-system-part-2/#backwards-compatibility-utility). Current releases have removed the dependency on this utility and the examples in this document have been updated correspondingly.
-
 The following information details installation and usage examples for `eslint-plugin-cypress` together with related plugins in an ESLint flat config environment.
 
 ## Installation
 
-It is recommended to use a minimum ESLint `8.x` version [eslint@8.57.0](https://github.com/eslint/eslint/releases/tag/v8.57.0) or ESLint `9.x`.
+Use a minimum ESLint `9.x`.
 
 ```shell
 npm install eslint eslint-plugin-cypress --save-dev
@@ -38,10 +36,10 @@ import pluginCypress from 'eslint-plugin-cypress/flat'
 
 There are two specific flat configurations available:
 
-| Configuration         | Content                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `configs.globals`     | defines globals `cy`, `Cypress`, `expect`, `assert` and `chai` used in Cypress test specs as well as `globals.browser` and `globals.mocha` from [globals](https://www.npmjs.com/package/globals). Additionally, `languageOptions` of `ecmaVersion: 2019` and `sourceType: 'module'` for backwards compatibility with earlier versions of this plugin are defined. There are no default rules enabled in this configuration. |
-| `configs.recommended` | enables [recommended Rules](README.md#rules). It includes also `configs.global` (see above)                                                                                                                                                                                                                                                                                                                                 |
+| Configuration         | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `configs.globals`     | defines globals `cy`, `Cypress`, `expect`, `assert` and `chai` used in Cypress test specs as well as `globals.browser` and `globals.mocha` from [globals](https://www.npmjs.com/package/globals). This version no longer specifies `languageOptions` for `ecmaVersion` and `sourceType` - see ESLint [JavaScript languageOptions](https://eslint.org/docs/latest/use/configure/language-options#specifying-javascript-options). There are no default rules enabled in this configuration. |
+| `configs.recommended` | enables [recommended Rules](README.md#rules). It includes also `configs.global` (see above)                                                                                                                                                                                                                                                                                                                                                                                               |
 
 In the following sections, different examples of possible configuration file contents are given, together with some brief explanations. Adapt these examples according to your needs.
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Note: If you installed ESLint globally then you must also install `eslint-plugin
 
 ## Installation
 
-Prerequisites: [ESLint](https://www.npmjs.com/package/eslint) `v7`, `v8` or `v9`.
-This plugin supports the use of [Flat config files](https://eslint.org/docs/latest/use/configure/configuration-files) with ESLint `8.57.0` and above.
+Prerequisites: [ESLint](https://www.npmjs.com/package/eslint) `v9`. Lower versions are no longer supported.
+This plugin supports the use of [Flat config files](https://eslint.org/docs/latest/use/configure/configuration-files) with ESLint `9.0.0` and above.
 
 ```sh
 npm install eslint-plugin-cypress --save-dev
@@ -17,15 +17,11 @@ or
 yarn add eslint-plugin-cypress --dev
 ```
 
-## Deprecations
-
-The use of ESLint `v7` and `v8` with `eslint-plugin-cypress` is deprecated and support will be removed in a future version of this plugin. ESLint `v7` reached end-of-life on Apr 9, 2022 and ESLint `v8` reached end-of-life on Oct 5, 2024. Users are encouraged to migrate to ESLint `v9`. See [ESLint Version Support](https://eslint.org/version-support/) for ESLint's current release lines.
-
 ## Usage
 
-If you are using ESLint `v7` or `v8`, then add an `.eslintrc.json` file to the root directory of your Cypress project with the contents shown below. You can continue to use this format with ESLint `v9` if you set the `ESLINT_USE_FLAT_CONFIG` environment variable to `false` (see [ESLint v9 > Configuration Files (Deprecated)](https://eslint.org/docs/latest/use/configure/configuration-files-deprecated)).
+ESLint `v9` uses a [Flat config file](https://eslint.org/docs/latest/use/configure/configuration-files) format with filename `eslint.config.*js` by default. Please refer to [Flat config installation and configuration details](FLAT-CONFIG.md).
 
-ESLint `v9` uses a [Flat config file](https://eslint.org/docs/latest/use/configure/configuration-files) format with filename `eslint.config.*js` by default. Please refer to [additional Flat config installation and configuration details](FLAT-CONFIG.md). (You may also use this with ESLint `8.57.0`.)
+You can continue to use a deprecated configuration `.eslintrc.json` with ESLint `v9` if you set the `ESLINT_USE_FLAT_CONFIG` environment variable to `false` (see [ESLint v9 > Configuration Files (Deprecated)](https://eslint.org/docs/latest/use/configure/configuration-files-deprecated)).
 
 ```json
 {

--- a/circle.yml
+++ b/circle.yml
@@ -5,13 +5,11 @@ workflows:
   main:
     jobs:
       - lint
-      - test-v7
       - test-v8
       - test-v9
       - release:
           requires:
             - lint
-            - test-v7
             - test-v8
             - test-v9
           filters:
@@ -34,27 +32,6 @@ jobs:
       - run:
           name: Lint code
           command: npm run lint
-
-  test-v7:
-    docker:
-      - image: cimg/node:20.12.2
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: npm ci
-      - run:
-          name: Remove unneeded plugins # minimum eslint@8.23.0 required
-          command: npm uninstall eslint-plugin-eslint-plugin eslint-plugin-n
-      - run:
-          name: Install ESLint 7
-          command: npm install eslint@7
-      - run:
-          name: Show ESLint version
-          command: npx eslint --version
-      - run:
-          name: Test ESLint 7
-          command: npm run test:legacy
 
   test-v8:
     docker:

--- a/lib/flat.js
+++ b/lib/flat.js
@@ -27,11 +27,6 @@ const commonGlobals =
     chai: false,
   }, globals.browser, globals.mocha)
 
-const commonLanguageOptions = {
-  ecmaVersion: 2019,
-  sourceType: 'module'
-}
-
 Object.assign(plugin.configs, {
   globals: {
     name: 'cypress/globals',
@@ -41,7 +36,6 @@ Object.assign(plugin.configs, {
     languageOptions: {
       globals:
         commonGlobals,
-      ...commonLanguageOptions
     }
   }
 })
@@ -61,7 +55,6 @@ Object.assign(plugin.configs, {
     languageOptions: {
       globals:
         commonGlobals,
-      ...commonLanguageOptions
     }
   }
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,21 +9,19 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "globals": "^13.20.0"
+        "globals": "^15.11.0"
       },
       "devDependencies": {
-        "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "^9.11.1",
         "eslint": "^9.12.0",
         "eslint-plugin-eslint-plugin": "^6.2.0",
         "eslint-plugin-mocha": "^10.5.0",
-        "eslint-plugin-n": "^17.10.3",
+        "eslint-plugin-n": "^17.11.1",
         "husky": "^9.1.6",
         "jest": "^29.7.0",
         "semantic-release": "24.1.2"
       },
       "peerDependencies": {
-        "eslint": ">=7"
+        "eslint": ">=9"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3650,10 +3648,39 @@
         "eslint": ">=7.0.0"
       }
     },
+    "node_modules/eslint-plugin-mocha/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-mocha/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/eslint-plugin-n": {
-      "version": "17.10.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.10.3.tgz",
-      "integrity": "sha512-ySZBfKe49nQZWR1yFaA0v/GsH6Fgp8ah6XV0WDz6CN8WO0ek4McMzb7A2xnf4DCYV43frjCygvb9f/wx7UUxRw==",
+      "version": "17.11.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.11.1.tgz",
+      "integrity": "sha512-93IUD82N6tIEgjztVI/l3ElHtC2wTa9boJHrD8iN+NyDxjxz/daZUZKfkedjBZNdg6EqDk4irybUsiPwDqXAEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3704,19 +3731,6 @@
       },
       "peerDependencies": {
         "eslint": ">=8"
-      }
-    },
-    "node_modules/eslint-plugin-n/node_modules/globals": {
-      "version": "15.9.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.9.0.tgz",
-      "integrity": "sha512-SmSKyLLKFbSr6rptvP8izbyxJL4ILwqO9Jg23UA0sDlGlu58V59D1//I3vlc0KJphVdUR7vMjHIplYnzBxorQA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-plugin-n/node_modules/minimatch": {
@@ -4431,25 +4445,12 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
+      "version": "15.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.11.0.tgz",
+      "integrity": "sha512-yeyNSjdbyVaWurlwCpcA6XNBrHTMIeDdj0/hnvX/OLJ9ekOXYbLsLinH/MucQyGvNnXhidTdNhTtJaffL2sMfw==",
+      "license": "MIT",
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/globals/node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -14347,12 +14348,29 @@
         "eslint-utils": "^3.0.0",
         "globals": "^13.24.0",
         "rambda": "^7.4.0"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "13.24.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+          "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        },
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-n": {
-      "version": "17.10.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.10.3.tgz",
-      "integrity": "sha512-ySZBfKe49nQZWR1yFaA0v/GsH6Fgp8ah6XV0WDz6CN8WO0ek4McMzb7A2xnf4DCYV43frjCygvb9f/wx7UUxRw==",
+      "version": "17.11.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.11.1.tgz",
+      "integrity": "sha512-93IUD82N6tIEgjztVI/l3ElHtC2wTa9boJHrD8iN+NyDxjxz/daZUZKfkedjBZNdg6EqDk4irybUsiPwDqXAEA==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.4.0",
@@ -14384,12 +14402,6 @@
             "@eslint-community/regexpp": "^4.6.0",
             "eslint-compat-utils": "^0.5.0"
           }
-        },
-        "globals": {
-          "version": "15.9.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-15.9.0.tgz",
-          "integrity": "sha512-SmSKyLLKFbSr6rptvP8izbyxJL4ILwqO9Jg23UA0sDlGlu58V59D1//I3vlc0KJphVdUR7vMjHIplYnzBxorQA==",
-          "dev": true
         },
         "minimatch": {
           "version": "9.0.5",
@@ -14781,19 +14793,9 @@
       }
     },
     "globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-      "requires": {
-        "type-fest": "^0.20.2"
-      },
-      "dependencies": {
-        "type-fest": {
-          "version": "0.20.2",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
-        }
-      }
+      "version": "15.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.11.0.tgz",
+      "integrity": "sha512-yeyNSjdbyVaWurlwCpcA6XNBrHTMIeDdj0/hnvX/OLJ9ekOXYbLsLinH/MucQyGvNnXhidTdNhTtJaffL2sMfw=="
     },
     "globby": {
       "version": "14.0.2",

--- a/package.json
+++ b/package.json
@@ -23,18 +23,16 @@
   },
   "homepage": "https://github.com/cypress-io/eslint-plugin-cypress#readme",
   "peerDependencies": {
-    "eslint": ">=7"
+    "eslint": ">=9"
   },
   "dependencies": {
-    "globals": "^13.20.0"
+    "globals": "^15.11.0"
   },
   "devDependencies": {
-    "@eslint/eslintrc": "^3.1.0",
-    "@eslint/js": "^9.11.1",
     "eslint": "^9.12.0",
     "eslint-plugin-eslint-plugin": "^6.2.0",
     "eslint-plugin-mocha": "^10.5.0",
-    "eslint-plugin-n": "^17.10.3",
+    "eslint-plugin-n": "^17.11.1",
     "husky": "^9.1.6",
     "jest": "^29.7.0",
     "semantic-release": "24.1.2"


### PR DESCRIPTION
- closes https://github.com/cypress-io/eslint-plugin-cypress/issues/228
- addresses issue https://github.com/cypress-io/eslint-plugin-cypress/issues/215 for flat config only

## Issue

ESLint versions < `v9` are no longer supported (see https://eslint.org/version-support/). [eslint-plugin-cypress](https://github.com/cypress-io/eslint-plugin-cypress) cannot rely on unsupported ESLint versions.

## Changes

Support for ESLint `v7` and `v8` is removed.

- Update `peerDependencies` in [package.json](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/package.json) to
  `"eslint": ">=9"`

- Delete `test-v7` from [circle.yml](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/circle.yml)

- Update [globals](https://www.npmjs.com/package/globals) to [15.11.0](https://www.npmjs.com/package/globals/v/15.11.0)

- Update [eslint-plugin-n](https://www.npmjs.com/package/eslint-plugin-n) to [17.11.1](https://github.com/eslint-community/eslint-plugin-n/releases/tag/v17.11.1)

- Remove `languageOptions` `ecmaVersion: 2019` and `sourceType: module` from the `eslint-plugin-cypress/flat` config

- Uninstall explicit `@eslint/eslintrc` and `@eslint/js`(installed automatically as dependency of `eslint`)

- Update documentation

  - [README](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/README.md)
  - [CONTRIBUTING](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/CONTRIBUTING.md)
  - [FLAT-CONFIG](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/FLAT-CONFIG.md)

## Notes

- [ ] `ci/circleci: test-v7` must be removed from branch protection rules. It is no longer used.

- `ci/circleci: test-v8` remains.

- ESLint `v8` is still used in [circle.yml](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/circle.yml) for the `test:legacy` script, since legacy configurations are still supported by ESLint `v9`.

 - The [v8 RuleTester](https://eslint.org/docs/v8.x/integrate/nodejs-api#ruletester) is however needed for legacy configurations as the [v9 RuleTester](https://eslint.org/docs/v9.x/integrate/nodejs-api#ruletester) only tests flat configurations. The blog post [eslintrc removed in ESLint v10.0.0](https://eslint.org/blog/2023/10/flat-config-rollout-plans/#eslintrc-removed-in-eslint-v10.0.0) announced plans to remove legacy configurations in ESLint `v10` scheduled for end of 2024 or early 2025. At the latest, at this point, [eslint-plugin-cypress](https://github.com/cypress-io/eslint-plugin-cypress) should follow suit and remove support for legacy configurations.

