### PR TITLE
docs: correct mocha flat example

### DIFF
--- a/FLAT-CONFIG.md
+++ b/FLAT-CONFIG.md
@@ -110,8 +110,8 @@ export default [
   pluginCypress.configs.recommended,
   {
     rules: {
-      'mocha/no-exclusive-tests': 'warn',
-      'mocha/no-skipped-tests': 'warn',
+      'mocha/no-exclusive-tests': 'error',
+      'mocha/no-skipped-tests': 'error',
       'mocha/no-mocha-arrows': 'off',
       'cypress/no-unnecessary-waiting': 'off'
     }


### PR DESCRIPTION
## Issue

The text and example code in [FLAT-CONFIG > Cypress and Mocha recommended](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/FLAT-CONFIG.md#cypress-and-mocha-recommended) disagree.

Whereas in the text it says:

> The settings for individual `mocha` rules from the `configs.flat.recommended` option are changed.
> - [mocha/no-exclusive-tests](https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/docs/rules/no-exclusive-tests.md) and [mocha/no-skipped-tests](https://github.com/lo1tuma/eslint-plugin-mocha/blob/main/docs/rules/no-skipped-tests.md) are set to `error` instead of `warn`

the example sets the rule to `warn` which is the same as the setting from [eslint-plugin-mocha](https://www.npmjs.com/package/eslint-plugin-mocha)'s flat file recommended option `configs.flat.recommended`.

## Change

Change the example rule setting to match the text. Use `error` throughout:

```js
    rules: {
      'mocha/no-exclusive-tests': 'error',
      'mocha/no-skipped-tests': 'error',
    ...
```
