### PR TITLE
docs: update chai-friendly flat example

### DIFF
--- a/FLAT-CONFIG.md
+++ b/FLAT-CONFIG.md
@@ -121,12 +121,12 @@ export default [
 
 ### Cypress and Chai recommended
 
-[eslint-plugin-chai-friendly](https://www.npmjs.com/package/eslint-plugin-chai-friendly) (minimum version [eslint-plugin-chai-friendly@0.8.0](https://github.com/ihordiachenko/eslint-plugin-chai-friendly/releases/tag/v0.8.0) required for ESLint v9 support and flat config support) is combined with the Cypress plugin `eslint-plugin-cypress`.
+[eslint-plugin-chai-friendly](https://www.npmjs.com/package/eslint-plugin-chai-friendly) is combined with the Cypress plugin `eslint-plugin-cypress`.
 
-The recommended rules for both plugins are used: `pluginCypress.configs.recommended` and `pluginChaiFriendly.configs.recommended`:
+The recommended rules for both plugins are used: `pluginCypress.configs.recommended` and `pluginChaiFriendly.configs.recommendedFlat`:
 
 ```shell
-npm install eslint-plugin-chai-friendly@^0.8.0 --save-dev
+npm install eslint-plugin-chai-friendly@^1.0.1 --save-dev
 ```
 
 ```js
@@ -134,7 +134,7 @@ import pluginCypress from 'eslint-plugin-cypress/flat'
 import pluginChaiFriendly from 'eslint-plugin-chai-friendly'
 export default [
   pluginCypress.configs.recommended,
-  pluginChaiFriendly.configs.recommended,
+  pluginChaiFriendly.configs.recommendedFlat,
   {
     rules: {
       'cypress/no-unnecessary-waiting': 'off',


### PR DESCRIPTION
## Issue

The flat example in [Cypress and Chai recommended](https://github.com/MikeMcC399/eslint-plugin-cypress/blob/prime/FLAT-CONFIG.md#cypress-and-chai-recommended) is outdated.

- [eslint-plugin-chai-friendly@0.8.0](https://github.com/ihordiachenko/eslint-plugin-chai-friendly/releases/tag/v0.8.0) shows the following message, indicating that the plugin version needs to be updated

> DEPRECATED ⚠️  - Critical bug fixed in 1.0.0

- [eslint-plugin-chai-friendly@1.0.0](https://github.com/ihordiachenko/eslint-plugin-chai-friendly/releases/tag/v1.0.0) renamed the flat configuration `recommended` to `recommendedFlat`

## Change

For the flat example in [Cypress and Chai recommended](https://github.com/MikeMcC399/eslint-plugin-cypress/blob/prime/FLAT-CONFIG.md#cypress-and-chai-recommended):

- remove the information about minimum version required
- update the version to `eslint-plugin-chai-friendly@^1.0.1`
- update the usage to `pluginChaiFriendly.configs.recommendedFlat`
