### PR TITLE
ci(deps): update to cimg/node:22.11.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,7 @@ workflows:
 jobs:
   lint:
     docker:
-      - image: cimg/node:20.12.2
+      - image: cimg/node:22.11.0
     steps:
       - checkout
       - run:
@@ -35,7 +35,7 @@ jobs:
 
   test-v8:
     docker:
-      - image: cimg/node:20.12.2
+      - image: cimg/node:22.11.0
     steps:
       - checkout
       - run:
@@ -53,7 +53,7 @@ jobs:
 
   test-v9:
     docker:
-      - image: cimg/node:20.12.2
+      - image: cimg/node:22.11.0
     steps:
       - checkout
       - run:
@@ -71,7 +71,7 @@ jobs:
 
   release:
     docker:
-      - image: cimg/node:20.12.2
+      - image: cimg/node:22.11.0
     steps:
       - checkout
       - run:


### PR DESCRIPTION
## Issue

The [circle.yml](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/circle.yml) workflow currently runs jobs using the [CircleCI Docker `cimg/node` image](https://circleci.com/developer/images/image/cimg/node) `cimg/node:20.12.2`. According to the [Node.js release schedule](https://github.com/nodejs/release#release-schedule) `20.x` moved to Maintenance LTS status on Oct 22, 2024.

The follow-on Node.js Active LTS version is Node.js `22.x`, which starts with the release of [Node.js 22.11.0](https://nodejs.org/en/blog/release/v22.11.0).

## Change

Update the [circle.yml](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/circle.yml) workflow to run jobs using the [CircleCI Docker `cimg/node` image](https://circleci.com/developer/images/image/cimg/node) `cimg/node:22.11.0` corresponding to the latest [Node.js Active LTS version](https://github.com/nodejs/release#release-schedule).
