### PR TITLE
ci(deps): update to cimg/node:22.14.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,11 @@
 version: 2.1
 
+executors:
+  docker-executor:
+    docker:
+      - image: cimg/node:22.14.0
+    resource_class: medium
+
 workflows:
   version: 2.1
   main:
@@ -19,8 +25,7 @@ workflows:
 
 jobs:
   lint:
-    docker:
-      - image: cimg/node:22.11.0
+    executor: docker-executor
     steps:
       - checkout
       - run:
@@ -34,8 +39,7 @@ jobs:
           command: npm run lint
 
   test-v8:
-    docker:
-      - image: cimg/node:22.11.0
+    executor: docker-executor
     steps:
       - checkout
       - run:
@@ -52,8 +56,7 @@ jobs:
           command: npm run test:legacy
 
   test-v9:
-    docker:
-      - image: cimg/node:22.11.0
+    executor: docker-executor
     steps:
       - checkout
       - run:
@@ -70,8 +73,7 @@ jobs:
           command: npm test
 
   release:
-    docker:
-      - image: cimg/node:22.11.0
+    executor: docker-executor
     steps:
       - checkout
       - run:


### PR DESCRIPTION
## Status

The [circle.yml](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/circle.yml) pipeline currently runs jobs using the [CircleCI Docker `cimg/node` image](https://circleci.com/developer/images/image/cimg/node) `cimg/node:22.11.0`.

[Node.js v22.11.0](https://nodejs.org/en/blog/release/v22.11.0) was released on Oct 29, 2024 and is part of the [Node.js Active LTS](https://github.com/nodejs/release#release-schedule) `22.x` release line.

The latest version in the `22.x` release line is now [Node.js v22.14.0](https://nodejs.org/en/blog/release/v22.14.0) which was released on Feb 11, 2025

## Change

Update the [circle.yml](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/circle.yml) pipeline:

1. to use [CircleCI reusable executors](https://circleci.com/docs/reusing-config/#authoring-reusable-executors) syntax to define the Docker `cimg/node` execution environment in one place in the [circle.yml](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/circle.yml) pipeline to enhance readability and maintainability ([DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle).

2. to run jobs using the [CircleCI Docker `cimg/node` image](https://circleci.com/developer/images/image/cimg/node) `cimg/node:22.14.0` corresponding to the latest [Node.js Active LTS version](https://github.com/nodejs/release#release-schedule).

As follows:

```yml
executors:
  docker-executor:
    docker:
      - image: cimg/node:22.14.0
    resource_class: medium
```
