### PR TITLE
chore(deps): update eslint-plugin-mocha to 11.1.0

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,7 @@ import mochaPlugin from 'eslint-plugin-mocha'
 export default [
   pluginJs.configs.recommended,
   eslintPlugin.configs['flat/recommended'],
-  mochaPlugin.configs.flat.recommended,
+  mochaPlugin.configs.recommended,
   {ignores: ['test-project/']},
   {
     languageOptions: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "eslint": "^9.24.0",
         "eslint-plugin-eslint-plugin": "^6.4.0",
-        "eslint-plugin-mocha": "^10.5.0",
+        "eslint-plugin-mocha": "^11.1.0",
         "husky": "^9.1.7",
         "jest": "^29.7.0",
         "semantic-release": "24.2.3"
@@ -3218,50 +3218,17 @@
       }
     },
     "node_modules/eslint-plugin-mocha": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-10.5.0.tgz",
-      "integrity": "sha512-F2ALmQVPT1GoP27O1JTZGrV9Pqg8k79OeIuvw63UxMtQKREZtmkK1NFgkZQ2TW7L2JSSFKHFPTtHu5z8R9QNRw==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-11.1.0.tgz",
+      "integrity": "sha512-rKntVWRsQFPbf8OkSgVNRVRrcVAPaGTyEgWCEyXaPDJkTl0v5/lwu1vTk5sWiUJU8l2sxwvGUZzSNrEKdVMeQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "eslint-utils": "^3.0.0",
-        "globals": "^13.24.0",
-        "rambda": "^7.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "@eslint-community/eslint-utils": "^4.4.1",
+        "globals": "^15.14.0"
       },
       "peerDependencies": {
-        "eslint": ">=7.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-mocha/node_modules/globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-plugin-mocha/node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "eslint": ">=9.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -3279,35 +3246,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=5"
-      }
-    },
-    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/eslint-visitor-keys": {
@@ -9007,13 +8945,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
-    },
-    "node_modules/rambda": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/rambda/-/rambda-7.5.0.tgz",
-      "integrity": "sha512-y/M9weqWAH4iopRd7EHDEQQvpFPHj1AA3oHozE9tfITHUtTR7Z9PSlIRRG2l1GuW7sefC1cXFfIcF+cgnShdBA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/rc": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "eslint": "^9.24.0",
     "eslint-plugin-eslint-plugin": "^6.4.0",
-    "eslint-plugin-mocha": "^10.5.0",
+    "eslint-plugin-mocha": "^11.1.0",
     "husky": "^9.1.7",
     "jest": "^29.7.0",
     "semantic-release": "24.2.3"


### PR DESCRIPTION
## Situation

This repo uses

https://github.com/cypress-io/eslint-plugin-cypress/blob/2c911ac76dad352fba1cd5e24fb6decb63118072/package.json#L34

The recent release [eslint-plugin-mocha@11.0.0](https://github.com/lo1tuma/eslint-plugin-mocha/releases/tag/11.0.0) has breaking changes including:

- Remove support for legacy configs and make the flat configs the default

## Change

- Migrate from [eslint-plugin-mocha@10.5.0](https://github.com/lo1tuma/eslint-plugin-mocha/releases/tag/10.5.0) to [eslint-plugin-mocha@11.1.0](https://github.com/lo1tuma/eslint-plugin-mocha/releases/tag/11.1.0) (current `latest`) for internal testing
- In [eslint.config.mjs](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/eslint.config.mjs) change from `mochaPlugin.configs.flat.recommended` to `mochaPlugin.configs.recommended`