### PR TITLE
feat: publish only core files to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
     ".": "./lib/flat.js",
     "./flat": "./lib/flat.js"
   },
+  "files": [
+    "lib",
+    "docs",
+    "CONTRIBUTING.md"
+  ],
   "author": "Cypress-io",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
## Situation

The npm package [eslint-plugin-cypress](https://www.npmjs.com/package/eslint-plugin-cypress) published to the [npm registry](https://www.npmjs.com/) includes files that are not necessary to run the plugin. This bloats the package making it twice the size it needs to be.

The current [package.json](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/package.json) contains no [files](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#files) options. When this option is omitted, it defaults to `["*"]`, which means it includes all files from the repo.

## Change

Add a [files](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#files) option to [package.json](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/package.json).

For linting add the directory:

- [lib](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/lib)

For links in the [README.md](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/README.md), add

- [docs](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/docs) directory
- [CONTRIBUTING.md](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/CONTRIBUTING.md) file

The following files are automatically included:

- [LICENSE](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/LICENSE)
- [README.md](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/README.md)
- [package.json](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/package.json)

Other files, that are used to set up the repo for development, in CI, for internal testing, and are not needed to run the plugin as a package, are not published with the package to the npm registry.

## Impact

The reduction for each of the following metrics related to the published npm package [eslint-plugin-cypress](https://www.npmjs.com/package/eslint-plugin-cypress) is approximately 65%:

| Metric        | Before   | After   |
| ------------- | -------- | ------- |
| \# files      | 84       | 30      |
| package size  | 37.2 kB  | 13.0 kB |
| unpacked size | 157.7 kB | 55.2 kB |

## Verification

Execute the following:

```shell
git clean -xfd
npm ci
npm pack
```

and inspect the list of files packed into the npm package. There should be 30 files in the package.

### Linting

```shell
mv eslint-plugin-cypress-0.0.0-development.tgz test-project
cd test-project
npm install eslint@latest eslint-plugin-cypress-0.0.0-development.tgz -D
npx eslint
npx eslint --config eslint-configs/eslint.default.mjs
npx eslint --config eslint-configs/eslint.default-deprecated.mjs
npx eslint --config eslint-configs/eslint.globals.mjs
npx eslint --config eslint-configs/eslint.recommended.mjs
```

No linting or other errors should be reported.

### Markdown links

```shell
npm install markdown-link-check -g
markdown-link-check node_modules/eslint-plugin-cypress/README.md
```

No link errors should be reported.

### Clean up

Clean up temporary files:

```shell
cd ..
git restore .
git clean -xfd
git status
```
