### PR TITLE
ci: add prettier linting

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
 npm run lint
+npm run format:check

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,11 @@
+# Add files here to ignore them from prettier formatting
+
+**/package-lock.json
+
+**/*.js
+**/*.?js
+**/*.ts
+**/*.?ts
+**/*.md
+
+test-project/cypress/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": false,
+  "trailingComma": "all",
+  "arrowParens": "always",
+  "singleQuote": true
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,7 @@ To add a new rule:
 * Run `eslint-doc-generator` to generate automated documentation sections (see [Document generation](#document-generation) below)
 * Review documentation changes
 * Run `npm run lint`
+* Run `npm run format`
 * Run `npm test` to run [Vitest](https://vitest.dev/)
 * Make sure all tests are passing
 * Add the rule to [flat.js](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/lib/flat.js)

--- a/circle.yml
+++ b/circle.yml
@@ -48,8 +48,11 @@ jobs:
           name: Show ESLint version
           command: npx eslint --version
       - run:
-          name: Lint code
+          name: Lint code with ESLint
           command: npm run lint
+      - run:
+          name: Lint code with Prettier
+          command: npm run format:check
 
   test-v9:
     executor: docker-executor

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "eslint-plugin-eslint-plugin": "^6.4.0",
         "eslint-plugin-mocha": "^11.1.0",
         "husky": "^9.1.7",
+        "prettier": "^3.5.3",
         "semantic-release": "24.2.5",
         "vitest": "^3.1.4"
       },
@@ -7393,6 +7394,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-ms": {

--- a/package.json
+++ b/package.json
@@ -34,12 +34,15 @@
     "eslint-plugin-eslint-plugin": "^6.4.0",
     "eslint-plugin-mocha": "^11.1.0",
     "husky": "^9.1.7",
+    "prettier": "^3.5.3",
     "semantic-release": "24.2.5",
     "vitest": "^3.1.4"
   },
   "scripts": {
     "lint": "eslint",
     "lint-fix": "eslint --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "semantic-release": "semantic-release",
     "test": "vitest run",
     "prepare": "husky"


### PR DESCRIPTION
## Status

JavaScript files are linted for stylistic formatting using [@stylistic/eslint-plugin](https://www.npmjs.com/package/@stylistic/eslint-plugin).

Other types of files are not linted for formatting.

## Assessment

[Prettier](https://prettier.io/) is used in some other Cypress repos to provide consistent code formatting, in addition to [@stylistic/eslint-plugin](https://www.npmjs.com/package/@stylistic/eslint-plugin). It [supports several file types](https://prettier.io/docs/) including the following used in this repo:

- JavaScript
- [JSON](https://json.org/)
- [Markdown](https://commonmark.org/)
- [YAML](https://yaml.org/)

JavaScript formatting is already the responsibility of [@stylistic/eslint-plugin](https://www.npmjs.com/package/@stylistic/eslint-plugin) in this repo. Prettier has a different opinion about JavaScript and the two cannot be used together. Cypress itself does not use Prettier to format code - see [CONTRIBUTING > Coding Style](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#coding-style).

## Change

- Implement Prettier source file formatting with [prettier@3.5.3](https://github.com/prettier/prettier/releases/tag/3.5.3)
- Target [JSON](https://json.org/) and [YAML](https://yaml.org/) initially
- Defer linting [Markdown](https://commonmark.org/) until a follow-on PR
- Exclude JavaScript and TypeScript from linting by Prettier
- Add scripts to [package.json](https://github.com/cypress-io/cypress-docker-images/blob/master/package.json)
    ```json
    "format": "prettier --write .",
    "format:check": "prettier --check .",
    ```
- Add instructions to the [CONTRIBUTING](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/CONTRIBUTING.md) document to run `format`
- Add `format:check` to [circle.yml](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/circle.yml) pipeline `lint` job and to [.husky/pre-commit](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/.husky/pre-commit)

## Verification

On Ubuntu `24.04.2` LTS, Node.js `22.16.0` LTS

Execute

```shell
git clean -xfd
npm ci
npm run format:check
```

and confirm
> All matched files use Prettier code style!

Execute

```shell
npm run format
```

and confirm that only the following file types are linted by Prettier at this time. Each should also be annotated with `(unchanged)`:

- `*.yml`
- `*.json`
