### PR TITLE
test: extend linting to customized test-project eslint config files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,7 +9,12 @@ export default [
   eslintPlugin.configs['flat/recommended'],
   mochaPlugin.configs.recommended,
   stylistic.configs.recommended,
-  { ignores: ['test-project/'] },
+  {
+    ignores: [
+      'test-project/**/*',
+      '!test-project/**/eslint*',
+    ],
+  },
   {
     languageOptions: {
       globals: globals.node,

--- a/test-project/eslint-configs/eslint.default-deprecated.mjs
+++ b/test-project/eslint-configs/eslint.default-deprecated.mjs
@@ -5,7 +5,7 @@ export default [
   pluginCypress.configs.recommended,
   {
     rules: {
-      'cypress/no-unnecessary-waiting': 'off'
-    }
-  }
+      'cypress/no-unnecessary-waiting': 'off',
+    },
+  },
 ]

--- a/test-project/eslint-configs/eslint.default.mjs
+++ b/test-project/eslint-configs/eslint.default.mjs
@@ -3,7 +3,7 @@ export default [
   pluginCypress.configs.recommended,
   {
     rules: {
-      'cypress/no-unnecessary-waiting': 'off'
-    }
-  }
+      'cypress/no-unnecessary-waiting': 'off',
+    },
+  },
 ]

--- a/test-project/eslint-configs/eslint.globals.mjs
+++ b/test-project/eslint-configs/eslint.globals.mjs
@@ -1,4 +1,2 @@
 import pluginCypress from 'eslint-plugin-cypress'
-export default [
-  pluginCypress.configs.globals
-]
+export default [pluginCypress.configs.globals]

--- a/test-project/eslint-configs/eslint.recommended.mjs
+++ b/test-project/eslint-configs/eslint.recommended.mjs
@@ -3,7 +3,7 @@ export default [
   pluginCypress.configs.recommended,
   {
     rules: {
-      'cypress/no-unnecessary-waiting': 'off'
-    }
-  }
+      'cypress/no-unnecessary-waiting': 'off',
+    },
+  },
 ]

--- a/test-project/eslint.config.mjs
+++ b/test-project/eslint.config.mjs
@@ -3,7 +3,7 @@ export default [
   pluginCypress.configs.recommended,
   {
     rules: {
-      'cypress/no-unnecessary-waiting': 'off'
-    }
-  }
+      'cypress/no-unnecessary-waiting': 'off',
+    },
+  },
 ]


### PR DESCRIPTION
## Situation

[eslint.config.mjs](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/eslint.config.mjs) uses `{ ignores: ['test-project/'] }` since most files are directly scaffolded from Cypress, however this means that customized files are also not linted.

There are currently some minor formatting differences in example ESLint config files in [test-project/eslint-configs](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/test-project/eslint-configs) compared to how they are shown in the [README](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/README.md) document.

## Change

Extend linting to include:

- [test-project/eslint.config.mjs](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/test-project/eslint.config.mjs)
- [test-project/eslint-configs](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/test-project/eslint-configs)

Make changes using `npx eslint --fix`.

Manually change [test-project/eslint-configs/eslint.globals.mjs](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/test-project/eslint-configs/eslint.globals.mjs) to conform to change made by Prettier to embedded JavaScript in Markdown in [README > Cypress globals](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/README.md#cypress-globals) section.

## Verification

```shell
npm run lint
```

and confirm that there are no errors reported.