### PR TITLE
fix: disallow extra properties in rule options

### DIFF
--- a/lib/rules/unsafe-to-chain-command.js
+++ b/lib/rules/unsafe-to-chain-command.js
@@ -49,6 +49,7 @@ const schema = {
       default: [],
     },
   },
+  additionalProperties: false,
 }
 
 /**


### PR DESCRIPTION
[unsafe-to-chain-command](https://github.com/cypress-io/eslint-plugin-cypress/blob/22b6122daba733a2cb47d77c892b38b2844369e1/lib/rules/unsafe-to-chain-command.js#L40) rule currently allows extra properties to be passed in options object, which should not be allowed. This makes it easier for typos in rule options to go unnoticed.

This PR simply disallows extra properties in this rule's schema.