### PR TITLE
docs: migrate https://docs.cypress.io/guides links

### DIFF
--- a/docs/rules/no-async-before.md
+++ b/docs/rules/no-async-before.md
@@ -46,5 +46,5 @@ If there are genuine use-cases for using `async/await` in your `before` hooks th
 
 ## Further Reading
 
-- [Mixing Async and Sync code](https://on.cypress.io/guides/core-concepts/introduction-to-cypress#Mixing-Async-and-Sync-code)
-- [Commands Are Asynchronous](https://on.cypress.io/guides/core-concepts/introduction-to-cypress.html#Commands-Are-Asynchronous)
+- [Mixing Async and Sync code](https://on.cypress.io/app/core-concepts/introduction-to-cypress#Mixing-Async-and-Sync-code)
+- [Commands Are Asynchronous](https://on.cypress.io/app/core-concepts/introduction-to-cypress.html#Commands-Are-Asynchronous)

--- a/docs/rules/no-async-tests.md
+++ b/docs/rules/no-async-tests.md
@@ -4,7 +4,7 @@
 
 <!-- end auto-generated rule header -->
 
-Cypress tests [that return a promise will error](https://docs.cypress.io/guides/references/error-messages.html#Cypress-detected-that-you-returned-a-promise-from-a-command-while-also-invoking-one-or-more-cy-commands-in-that-promise) and cannot run successfully.
+Cypress tests [that return a promise will error](https://docs.cypress.io/app/references/error-messages.html#Cypress-detected-that-you-returned-a-promise-from-a-command-while-also-invoking-one-or-more-cy-commands-in-that-promise) and cannot run successfully.
 An `async` function returns a promise under the hood, so a test using an `async` function will also error.
 
 ## Rule Details
@@ -49,5 +49,5 @@ If there are genuine use-cases for using `async/await` in your test cases then y
 
 ## Further Reading
 
-- [Mixing Async and Sync code](https://on.cypress.io/guides/core-concepts/introduction-to-cypress#Mixing-Async-and-Sync-code)
-- [Commands Are Asynchronous](https://on.cypress.io/guides/core-concepts/introduction-to-cypress.html#Commands-Are-Asynchronous)
+- [Mixing Async and Sync code](https://on.cypress.io/app/core-concepts/introduction-to-cypress#Mixing-Async-and-Sync-code)
+- [Commands Are Asynchronous](https://on.cypress.io/app/core-concepts/introduction-to-cypress.html#Commands-Are-Asynchronous)

--- a/docs/rules/no-force.md
+++ b/docs/rules/no-force.md
@@ -4,7 +4,7 @@
 
 Using `force: true` on inputs appears to be confusing rather than helpful.
 It usually silences the actual problem instead of providing a way to overcome it.
-See [Cypress Core Concepts](https://docs.cypress.io/guides/core-concepts/interacting-with-elements.html#Forcing).
+See [Cypress Core Concepts](https://docs.cypress.io/app/core-concepts/interacting-with-elements.html#Forcing).
 
 If enabling this rule, it's recommended to set the severity to `warn`.
 

--- a/docs/rules/no-xpath.md
+++ b/docs/rules/no-xpath.md
@@ -22,4 +22,4 @@ cy.get('[data-cy="container"]').click()
 
 Both `@cypress/xpath` and `cypress-xpath` are deprecated.
 
-See [the Cypress Best Practices guide](https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements).
+See [the Cypress Best Practices guide](https://docs.cypress.io/app/core-concepts/best-practices.html#Selecting-Elements).

--- a/docs/rules/require-data-selectors.md
+++ b/docs/rules/require-data-selectors.md
@@ -27,4 +27,4 @@ cy.get('[data-QA=submit]')
 
 ## Further Reading
 
-See [the Cypress Best Practices guide](https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements).
+See [the Cypress Best Practices guide](https://docs.cypress.io/app/core-concepts/best-practices.html#Selecting-Elements).

--- a/docs/rules/unsafe-to-chain-command.md
+++ b/docs/rules/unsafe-to-chain-command.md
@@ -16,4 +16,4 @@
 
 ## Further Reading
 
-See [retry-ability guide](https://docs.cypress.io/guides/core-concepts/retry-ability#Actions-should-be-at-the-end-of-chains-not-the-middle).
+See [retry-ability guide](https://docs.cypress.io/app/core-concepts/retry-ability#Actions-should-be-at-the-end-of-chains-not-the-middle).

--- a/lib/rules/unsafe-to-chain-command.js
+++ b/lib/rules/unsafe-to-chain-command.js
@@ -7,7 +7,7 @@ const DESCRIPTION = 'disallow actions within chains'
 
 /**
  * Commands listed in the documentation with text: 'It is unsafe to chain further commands that rely on the subject after xxx.'
- * See {@link https://docs.cypress.io/guides/core-concepts/retry-ability#Actions-should-be-at-the-end-of-chains-not-the-middle Actions should be at the end of chains, not the middle}
+ * See {@link https://docs.cypress.io/app/core-concepts/retry-ability#Actions-should-be-at-the-end-of-chains-not-the-middle Actions should be at the end of chains, not the middle}
  * for more information.
  *
  * @type {string[]}


### PR DESCRIPTION
## Situation

Multiple links in [docs/rules/*.md](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/docs/rules) files are using outdated links to the Cypress documentation website https://docs.cypress.io/ which was restructured.

The links do however currently forward to the correct (new) destinations.

For example:

https://docs.cypress.io/guides/references/error-messages.html#Cypress-detected-that-you-returned-a-promise-from-a-command-while-also-invoking-one-or-more-cy-commands-in-that-promise

forwards to the new location

https://docs.cypress.io/app/references/error-messages#Cypress-detected-that-you-returned-a-promise-from-a-command-while-also-invoking-one-or-more-cy-commands-in-that-promise

## Change

- To eliminate the necessity and risk of forwarding, update links referring to https://*.cypress.io/guides so they need no forwarding applied.

## Verification

```shell
npm install markdown-link-check -g
cd docs/rules
markdown-link-check .
```
