### PR TITLE
chore: update test-project for Cypress 15.0.0

### DIFF
--- a/test-project/README.md
+++ b/test-project/README.md
@@ -18,12 +18,6 @@ npx cypress open
 - Select "Scaffold example specs"
 - Close all Cypress windows
 
-Test that scaffolded specs run:
-
-```shell
-npm test
-```
-
 Remove Cypress from `package.json`:
 
 ```shell

--- a/test-project/cypress/e2e/2-advanced-examples/actions.cy.js
+++ b/test-project/cypress/e2e/2-advanced-examples/actions.cy.js
@@ -17,9 +17,9 @@ context('Actions', () => {
     cy.get('.action-email').type('{del}{selectall}{backspace}')
 
     // .type() with key modifiers
-    cy.get('.action-email').type('{alt}{option}') //these are equivalent
-    cy.get('.action-email').type('{ctrl}{control}') //these are equivalent
-    cy.get('.action-email').type('{meta}{command}{cmd}') //these are equivalent
+    cy.get('.action-email').type('{alt}{option}') // these are equivalent
+    cy.get('.action-email').type('{ctrl}{control}') // these are equivalent
+    cy.get('.action-email').type('{meta}{command}{cmd}') // these are equivalent
     cy.get('.action-email').type('{shift}')
 
     // Delay each keypress by 0.1 sec

--- a/test-project/cypress/e2e/2-advanced-examples/cypress_api.cy.js
+++ b/test-project/cypress/e2e/2-advanced-examples/cypress_api.cy.js
@@ -1,7 +1,6 @@
 /// <reference types="cypress" />
 
 context('Cypress APIs', () => {
-
   context('Cypress.Commands', () => {
     beforeEach(() => {
       cy.visit('https://example.cypress.io/cypress-api')

--- a/test-project/cypress/e2e/2-advanced-examples/misc.cy.js
+++ b/test-project/cypress/e2e/2-advanced-examples/misc.cy.js
@@ -43,12 +43,20 @@ context('Misc', () => {
     if (Cypress.platform === 'win32') {
       cy.exec(`print ${Cypress.config('configFile')}`)
         .its('stderr').should('be.empty')
-    } else {
+    }
+    else {
       cy.exec(`cat ${Cypress.config('configFile')}`)
         .its('stderr').should('be.empty')
 
-      cy.exec('pwd')
-        .its('code').should('eq', 0)
+      cy.log(`Cypress version ${Cypress.version}`)
+      if (Cypress.version.split('.').map(Number)[0] < 15) {
+        cy.exec('pwd')
+          .its('code').should('eq', 0)
+      }
+      else {
+        cy.exec('pwd')
+          .its('exitCode').should('eq', 0)
+      }
     }
   })
 

--- a/test-project/cypress/e2e/2-advanced-examples/storage.cy.js
+++ b/test-project/cypress/e2e/2-advanced-examples/storage.cy.js
@@ -64,9 +64,9 @@ context('Local Storage / Session Storage', () => {
       expect(storageMap).to.deep.equal({
         // other origins will also be present if localStorage is set on them
         'https://example.cypress.io': {
-          'prop1': 'red',
-          'prop2': 'blue',
-          'prop3': 'magenta',
+          prop1: 'red',
+          prop2: 'blue',
+          prop3: 'magenta',
         },
       })
     })
@@ -94,9 +94,9 @@ context('Local Storage / Session Storage', () => {
       expect(storageMap).to.deep.equal({
         // other origins will also be present if sessionStorage is set on them
         'https://example.cypress.io': {
-          'prop4': 'cyan',
-          'prop5': 'yellow',
-          'prop6': 'black',
+          prop4: 'cyan',
+          prop5: 'yellow',
+          prop6: 'black',
         },
       })
     })


### PR DESCRIPTION
## Situation

[Cypress 15.0.0](https://docs.cypress.io/app/references/changelog#15-0-0) and previous releases made changes to scaffolded tests used in the [test-project](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/test-project)

## Change

Re-scaffold the [test-project](https://github.com/cypress-io/eslint-plugin-cypress/tree/master/test-project) using the instructions in the [test-project > README](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/test-project/README.md) document. These are mainly formatting changes due to prior linting. One change for `cy.exec()` is also introduced for Cypress 15 compatibility. Cypress is however only used to set up the test project, it is not required in CI for testing linting.

Remove a duplicated step for testing in the [test-project > README](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/test-project/README.md).
