### PR TITLE
chore(deps): update eslint-plugin-eslint-plugin to 7.0.0

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,7 @@ import stylistic from '@stylistic/eslint-plugin'
 
 export default [
   pluginJs.configs.recommended,
-  eslintPlugin.configs['flat/recommended'],
+  eslintPlugin.configs.recommended,
   mochaPlugin.configs.recommended,
   stylistic.configs.recommended,
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@stylistic/eslint-plugin": "^5.3.1",
         "eslint": "^9.35.0",
-        "eslint-plugin-eslint-plugin": "^6.5.0",
+        "eslint-plugin-eslint-plugin": "^7.0.0",
         "eslint-plugin-mocha": "^11.1.0",
         "husky": "^9.1.7",
         "prettier": "^3.6.2",
@@ -2608,9 +2608,9 @@
       }
     },
     "node_modules/eslint-plugin-eslint-plugin": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-6.5.0.tgz",
-      "integrity": "sha512-DT8YpcXDtMBcBZN39JlkHGurHKU8eYFLavTrnowQLeNwqe/diRUsllsftgD/7dZ2/ItabNLLF2/EYapE1H+G7Q==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-7.0.0.tgz",
+      "integrity": "sha512-EgiW9zf4PbqA+yN9T6Z8bHx46+fWtAIXFrYkL4nSTnI84LnTKmzjh+cIJaVAyFVZveKUSG8LcVe1suGG78qZPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2618,10 +2618,10 @@
         "estraverse": "^5.3.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.1 || >=24.0.0"
       },
       "peerDependencies": {
-        "eslint": ">=8.23.0"
+        "eslint": ">=9.0.0"
       }
     },
     "node_modules/eslint-plugin-mocha": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@stylistic/eslint-plugin": "^5.3.1",
     "eslint": "^9.35.0",
-    "eslint-plugin-eslint-plugin": "^6.5.0",
+    "eslint-plugin-eslint-plugin": "^7.0.0",
     "eslint-plugin-mocha": "^11.1.0",
     "husky": "^9.1.7",
     "prettier": "^3.6.2",


### PR DESCRIPTION
## Situation

[eslint-plugin-eslint-plugin](https://www.npmjs.com/package/eslint-plugin-eslint-plugin) is an ESLint plugin for linting ESLint plugins.

The repo is configured with [eslint-plugin-eslint-plugin@6.5.0](https://github.com/eslint-community/eslint-plugin-eslint-plugin/releases/tag/v6.5.0). The latest version is [eslint-plugin-eslint-plugin@7.0.0](https://github.com/eslint-community/eslint-plugin-eslint-plugin/releases/tag/v7.0.0).

## Change

Update from

[eslint-plugin-eslint-plugin@6.5.0](https://github.com/eslint-community/eslint-plugin-eslint-plugin/releases/tag/v6.5.0)

to

[eslint-plugin-eslint-plugin@7.0.0](https://github.com/eslint-community/eslint-plugin-eslint-plugin/releases/tag/v7.0.0)

Migrate to the new recommended config syntax `eslintPlugin.configs.recommended`.
