### PR TITLE
feat: add type declaration file

### DIFF
--- a/lib/flat.d.ts
+++ b/lib/flat.d.ts
@@ -1,11 +1,11 @@
-import type {ESLint, Linter} from 'eslint'
+import type { ESLint, Linter } from 'eslint'
 
 declare const plugin: {
-  meta: { name: string, version: string },
+  meta: { name: string, version: string }
   configs: {
-    globals: Linter.Config<Linter.RulesRecord>,
-    recommended: Linter.Config<Linter.RulesRecord>,
-  },
+    globals: Linter.Config<Linter.RulesRecord>
+    recommended: Linter.Config<Linter.RulesRecord>
+  }
   rules: NonNullable<ESLint.Plugin['rules']>
 }
 


### PR DESCRIPTION
Hand roll a type declaration file for `flat.js` that accurately reflects the exported plugin. This resolves type errors when attempting to use `globals` and `recommended` configs in type-checked eslint configs and also aids in autocomplete when typing (as in keyboard button press, not "does it satisfy expected type") properties of the plugin.

Fixes #232

Note: I verified `flat.d.ts` is included in the npm package with `npm pack` and then also verified the types work in another project by installing that package.