### PR TITLE
feat: expand no-xpath message text

### DIFF
--- a/docs/rules/no-xpath.md
+++ b/docs/rules/no-xpath.md
@@ -20,8 +20,11 @@ Examples of **correct** code for this rule:
 cy.get('[data-cy="container"]').click()
 ```
 
-## Further Reading
+## Deprecation and Support
 
-Both `@cypress/xpath` and `cypress-xpath` are deprecated.
+Both [@cypress/xpath](https://www.npmjs.com/package/@cypress/xpath) and the earlier [cypress-xpath](https://www.npmjs.com/package/cypress-xpath) npm packages are deprecated and no longer supported.
+These packages previously provided the command `cy.xpath()` and they should be uninstalled from the Cypress project after migrating `cy.xpath()` selection to `cy.get()`. See below for more details.
+
+## Further Reading
 
 See [the Cypress Best Practices guide](https://docs.cypress.io/app/core-concepts/best-practices.html#Selecting-Elements).

--- a/lib/rules/no-xpath.js
+++ b/lib/rules/no-xpath.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   meta: {
-    type: 'suggestion',
+    type: 'problem',
     docs: {
       description: 'disallow using `cy.xpath()` calls',
       recommended: false,
@@ -11,7 +11,9 @@ module.exports = {
     fixable: null, // Or `code` or `whitespace`
     schema: [], // Add a schema if the rule has options
     messages: {
-      unexpected: 'Avoid using cy.xpath command',
+      unexpected:
+        'cy.xpath() is deprecated and unsupported. '
+        + 'Consider using cy.get() with appropriate selectors instead.',
     },
   },
 


### PR DESCRIPTION
## Situation

The rule [cypress/no-xpath](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-xpath.md) emits the message "Avoid using cy.xpath command" when triggered. The rule is classified as a `suggestion`.

https://github.com/cypress-io/eslint-plugin-cypress/blob/b228de3e1831b2b966d10758bd55ffe7d73254c5/lib/rules/no-xpath.js#L14

[@cypress/xpath](https://www.npmjs.com/package/@cypress/xpath) was deprecated on June 1, 2023 and `cy.xpath()` is unsupported since then.

## Timeline

- The npm package [cypress-xpath](https://www.npmjs.com/package/cypress-xpath) was last published as [cypress-xpath@2.0.1](https://www.npmjs.com/package/cypress-xpath/v/2.0.1) in July 2022. It is deprecated and was replaced by [@cypress/xpath](https://www.npmjs.com/package/@cypress/xpath).

- The npm package [@cypress/xpath](https://www.npmjs.com/package/@cypress/xpath) was last published as [@cypress/xpath@2.0.3](https://www.npmjs.com/package/@cypress/xpath/v/2.0.3) in October 2022. It is deprecated and no longer supported.

- https://github.com/cypress-io/cypress/pull/26893 deprecated [@cypress/xpath](https://www.npmjs.com/package/@cypress/xpath) on June 1, 2023

- https://github.com/cypress-io/eslint-plugin-cypress/issues/218 requested creation of a rule to prevent using `xpath` in August 2024.

- https://github.com/cypress-io/eslint-plugin-cypress/pull/247 introduced the rule [cypress/no-xpath](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-xpath.md) in [eslint-plugin-cypress@4.2.0](https://github.com/cypress-io/eslint-plugin-cypress/releases/tag/v4.2.0) on March 7, 2025

## Change

Extend the message for [cypress/no-xpath](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-xpath.md) to state more clearly that `cy.xpath` is no longer supported and suggest more concrete actions.

Raise the [rule type](https://eslint.org/docs/latest/extend/custom-rules#rule-structure) from `suggestion` to `problem`, since this corresponds to the continued use of now unsupported functionality. This is a documentation-only change, since the rule type only comes into play for rules with "fix" functionality. That is not the case for this rule.

## Examples

**BEFORE**

>  6:3  error  Avoid using cy.xpath command  cypress/no-xpath

**AFTER**

>  6:3  error  cy.xpath() is deprecated and unsupported. Consider using cy.get() with appropriate selectors instead  cypress/no-xpath

## Verification

```shell
npm ci
npm test
npm run lint
```
