### PR TITLE
chore: add minimum release age and vulnerability alerts to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,11 @@
   },
   "prConcurrentLimit": 10,
   "prHourlyLimit": 2,
+  "minimumReleaseAge": "7 days",
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": "0 days"
+  },
   "rangeStrategy": "bump",
   "lockFileMaintenance": {
     "enabled": true
@@ -21,6 +26,10 @@
     {
       "matchPackageNames": ["/eslint/"],
       "groupName": "eslint"
+    },
+    {
+      "matchPackageNames": ["cypress"],
+      "minimumReleaseAge": "0 days"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add a 7-day `minimumReleaseAge` for all dependencies to avoid pulling in potentially unstable new releases
- Exempt the `cypress` package from this cooldown so updates are available immediately
- Enable `osvVulnerabilityAlerts` for OSV vulnerability scanning
- Add `vulnerabilityAlerts` config to bypass the 7-day cooldown for security fixes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d74c0fa58909127dde28d852a07ce9b7efc884b0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->