### PR TITLE
chore(deps): add cypress to allowScripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,8 @@
     "format:check": "prettier --check .",
     "test": "vitest run",
     "prepare": "husky"
+  },
+  "allowScripts": {
+    "cypress": true
   }
 }


### PR DESCRIPTION
## Situation

Executing `npm ci` under Node.js 24.18.0 in alignment with the value in [.node-version](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/.node-version), outputs the following warning:

```console
npm warn allow-scripts 1 package has install scripts not yet covered by allowScripts:
npm warn allow-scripts   cypress@15.18.1 (postinstall: node dist/index.js --exec install)
npm warn allow-scripts
npm warn allow-scripts Run `npm approve-scripts --allow-scripts-pending` to review, or `npm approve-scripts <pkg>` to allow.
```

This does not currently show in CircleCI, since the version of Node.js there is lagging behind. See also issue https://github.com/cypress-io/eslint-plugin-cypress/pull/380 to get Renovate to start maintaining and updating the Node.js version in CircleCI. It can therefore soon be expected to appear as a warning in CI.

## Change

Execute

```console
npm approve-scripts cypress --no-allow-scripts-pin
```

to add an `allowScripts` key to `package.json` in order to silence the warning from `npm@11.16.0`.

## Verification

Execute the following and confirm there is no `allow-scripts` warning:

```shell
git clean -xfd
npm ci
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Install-time npm configuration only; no changes to runtime, auth, or plugin logic.
> 
> **Overview**
> Adds an **`allowScripts`** entry in **`package.json`** so **`npm ci`** on npm 11+ (e.g. Node 24) no longer warns that **`cypress`**’s postinstall script is not approved.
> 
> This is the result of **`npm approve-scripts cypress`** and only affects install-time script policy—not application or lint behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7eb3060067ad993027bff7d7d38cc8cc6d5120bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->