### PR TITLE
fix(docs): add no-and rule documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,22 +53,24 @@ These rules enforce some of the [best practices recommended for using Cypress](h
 
 💼 Configurations enabled in.\
 ✅ Set in the `recommended` configuration.\
+🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\
 ❌ Deprecated.
 
-| Name                                                                     | Description                                                | 💼 | ❌  |
-| :----------------------------------------------------------------------- | :--------------------------------------------------------- | :- | :- |
-| [assertion-before-screenshot](docs/rules/assertion-before-screenshot.md) | require screenshots to be preceded by an assertion         |    |    |
-| [no-assigning-return-values](docs/rules/no-assigning-return-values.md)   | disallow assigning return values of `cy` calls             | ✅  |    |
-| [no-async-before](docs/rules/no-async-before.md)                         | disallow using `async`/`await` in Cypress `before` methods |    |    |
-| [no-async-tests](docs/rules/no-async-tests.md)                           | disallow using `async`/`await` in Cypress test cases       | ✅  |    |
-| [no-chained-get](docs/rules/no-chained-get.md)                           | disallow chain of `cy.get()` calls                         |    |    |
-| [no-debug](docs/rules/no-debug.md)                                       | disallow using `cy.debug()` calls                          |    |    |
-| [no-force](docs/rules/no-force.md)                                       | disallow using `force: true` with action commands          |    |    |
-| [no-pause](docs/rules/no-pause.md)                                       | disallow using `cy.pause()` calls                          |    |    |
-| [no-unnecessary-waiting](docs/rules/no-unnecessary-waiting.md)           | disallow waiting for arbitrary time periods                | ✅  |    |
-| [no-xpath](docs/rules/no-xpath.md)                                       | disallow using `cy.xpath()` calls                          |    | ❌  |
-| [require-data-selectors](docs/rules/require-data-selectors.md)           | require `data-*` attribute selectors                       |    |    |
-| [unsafe-to-chain-command](docs/rules/unsafe-to-chain-command.md)         | disallow actions within chains                             | ✅  |    |
+| Name                                                                     | Description                                                     | 💼 | 🔧 | ❌  |
+| :----------------------------------------------------------------------- | :-------------------------------------------------------------- | :- | :- | :- |
+| [assertion-before-screenshot](docs/rules/assertion-before-screenshot.md) | require screenshots to be preceded by an assertion              |    |    |    |
+| [no-and](docs/rules/no-and.md)                                           | enforce `.should()` over `.and()` for starting assertion chains |    | 🔧 |    |
+| [no-assigning-return-values](docs/rules/no-assigning-return-values.md)   | disallow assigning return values of `cy` calls                  | ✅  |    |    |
+| [no-async-before](docs/rules/no-async-before.md)                         | disallow using `async`/`await` in Cypress `before` methods      |    |    |    |
+| [no-async-tests](docs/rules/no-async-tests.md)                           | disallow using `async`/`await` in Cypress test cases            | ✅  |    |    |
+| [no-chained-get](docs/rules/no-chained-get.md)                           | disallow chain of `cy.get()` calls                              |    |    |    |
+| [no-debug](docs/rules/no-debug.md)                                       | disallow using `cy.debug()` calls                               |    |    |    |
+| [no-force](docs/rules/no-force.md)                                       | disallow using `force: true` with action commands               |    |    |    |
+| [no-pause](docs/rules/no-pause.md)                                       | disallow using `cy.pause()` calls                               |    |    |    |
+| [no-unnecessary-waiting](docs/rules/no-unnecessary-waiting.md)           | disallow waiting for arbitrary time periods                     | ✅  |    |    |
+| [no-xpath](docs/rules/no-xpath.md)                                       | disallow using `cy.xpath()` calls                               |    |    | ❌  |
+| [require-data-selectors](docs/rules/require-data-selectors.md)           | require `data-*` attribute selectors                            |    |    |    |
+| [unsafe-to-chain-command](docs/rules/unsafe-to-chain-command.md)         | disallow actions within chains                                  | ✅  |    |    |
 
 <!-- end auto-generated rules list -->
 <!-- prettier-ignore-end -->

--- a/lib/rules/no-and.js
+++ b/lib/rules/no-and.js
@@ -7,7 +7,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'enforce .should() over .and() for starting assertion chains',
+      description: 'enforce `.should()` over `.and()` for starting assertion chains',
       recommended: false,
       url: 'https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-and.md',
     },


### PR DESCRIPTION
- closes https://github.com/cypress-io/eslint-plugin-cypress/issues/378

## Situation

The rule [cypress/no-and](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-and.md) is not listed in the [README > Rules](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/README.md#rules) section.

The documentation is not synced using the required [eslint-doc-generator](https://www.npmjs.com/package/eslint-doc-generator) described in the [CONTRIBUTING > Document generation](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/CONTRIBUTING.md#document-generation) section.

## Change

Add code quotes to the [lib/rules/no-and.js](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/lib/rules/no-and.js) description for consistency with other rules and with the [docs/rules/no-and.md](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-and.md) document.

Install and run [eslint-doc-generator](https://www.npmjs.com/package/eslint-doc-generator) to generate consistent documentation.

This adds [cypress/no-and](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-and.md) to the [README > Rules](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/README.md#rules) section, which now has an additional column for "Automatically fixable by the `--fix` CLI option".

This PR has a commit message type of `fix` in order to trigger a new release. The changed files are part of the published package (see https://www.npmjs.com/package/eslint-plugin-cypress?activeTab=code) and therefore a release is needed.

## Verification

```shell
npm ci
npm run format:check
npm run lint
npm test
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a cosmetic rule metadata string only; no lint behavior or runtime logic changes.
> 
> **Overview**
> **README rules documentation** is regenerated so **`cypress/no-and`** appears in the auto-generated rules table, with a new **🔧** column marking rules that ESLint can auto-fix via `--fix` (the rule is marked fixable there).
> 
> In **`lib/rules/no-and.js`**, the rule’s `meta.docs.description` now uses backticks around **`.should()`** and **`.and()`** so generated docs match other rules and the existing `docs/rules/no-and.md` wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fed22eea7d86758897ada4a571223fc8a5e14481. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->