### PR TITLE
chore(renovate): add cimg/node Docker image to config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,6 +30,11 @@
     {
       "matchPackageNames": ["cypress"],
       "minimumReleaseAge": "0 days"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["cimg/node"],
+      "allowedVersions": "<25"
     }
   ]
 }


### PR DESCRIPTION
## Situation

Renovate has been updating the [.node-version](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/.node-version) and [.nvmrc](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/.nvmrc) contents regularly, so that they currently contain `24.18.0` as a Node.js definition.

The [circle.yml](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/circle.yml) pipeline, on the other hand, is not being updated by Renovate and the Docker image `cimg/node` remains at `24.13.1` from Feb 2026.

## Change

Add `cimg/node`, limited to Node.js 24.x, to the [renovate.json](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/renovate.json) `packageRules` configuration:

```json
    {
      "matchDatasources": ["docker"],
      "matchPackageNames": ["cimg/node"],
      "allowedVersions": "<25"
    }
```

Local tests and CircleCI test should then use a more or less consistent version of Node.js in future.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Renovate-only configuration change with no application or CI logic changes until separate upgrade PRs are merged.
> 
> **Overview**
> Adds a Renovate **package rule** so the CircleCI **`cimg/node`** image (used in `circle.yml`) gets dependency updates alongside `.node-version` / `.nvmrc`, which were already on newer Node 24 patch releases while CI stayed on **`24.13.1`**.
> 
> The rule targets the **docker** datasource, matches **`cimg/node`**, and sets **`allowedVersions`: `<25`** so Renovate can bump patch/minor 24.x images without proposing Node 25+.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28be3d6c03f786b98e154ba8a33ccca9e05a0509. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->