### PR TITLE
test: update scaffolded test-project

### DIFF
--- a/test-project/README.md
+++ b/test-project/README.md
@@ -6,15 +6,14 @@ This project can be updated to the latest Cypress default scaffolded E2E test sp
 
 ```shell
 rm -rf cypress cypress.config.js
+git clean -xfd
 npm install cypress@latest --no-package-lock
-npx cypress open
+npx cypress open --e2e --browser electron
 ```
 
-- Select "Continue" for "What's New in Cypress" if displayed
-- Select "E2E Testing"
+
 - Select "Continue" in "Configuration files"
-- Select "Electron" browser
-- Select "Start E2E Testing in Electron"
+- Select "Continue" for "What's New in Cypress" if displayed
 - Select "Scaffold example specs"
 - Close all Cypress windows
 
@@ -34,7 +33,7 @@ To test the project locally:
 cd test-project
 npm install eslint@latest eslint-plugin-cypress@latest @typescript-eslint/parser@latest cypress@latest -D
 npx cypress run
-npx eslint
+npx eslint --config eslint-configs/eslint.recommended.mjs
 ```
 
 Do not commit the changes from installing the above dependencies.

--- a/test-project/cypress.config.js
+++ b/test-project/cypress.config.js
@@ -1,6 +1,8 @@
 const { defineConfig } = require("cypress");
 
 module.exports = defineConfig({
+  allowCypressEnv: false,
+
   e2e: {
     setupNodeEvents(on, config) {
       // implement node event listeners here

--- a/test-project/cypress/e2e/2-advanced-examples/actions.cy.js
+++ b/test-project/cypress/e2e/2-advanced-examples/actions.cy.js
@@ -239,24 +239,33 @@ context('Actions', () => {
     // because they're not within
     // the viewable area of their parent
     // (we need to scroll to see them)
-    cy.get('#scroll-horizontal button')
-      .should('not.be.visible')
+    cy.get('#scroll-horizontal button').then(($el) => {
+      const container = $el[0].closest('#scroll-horizontal')
+      expect($el[0].getBoundingClientRect().left).to.be.greaterThan(container.getBoundingClientRect().right)
+    })
 
     // scroll the button into view, as if the user had scrolled
     cy.get('#scroll-horizontal button').scrollIntoView()
     cy.get('#scroll-horizontal button')
       .should('be.visible')
 
-    cy.get('#scroll-vertical button')
-      .should('not.be.visible')
+    cy.get('#scroll-vertical button').then(($el) => {
+      const container = $el[0].closest('#scroll-vertical')
+      expect($el[0].getBoundingClientRect().top).to.be.greaterThan(container.getBoundingClientRect().bottom)
+    })
 
     // Cypress handles the scroll direction needed
     cy.get('#scroll-vertical button').scrollIntoView()
     cy.get('#scroll-vertical button')
       .should('be.visible')
 
-    cy.get('#scroll-both button')
-      .should('not.be.visible')
+    cy.get('#scroll-both button').then(($el) => {
+      const container = $el[0].closest('#scroll-both')
+      const elRect = $el[0].getBoundingClientRect()
+      const containerRect = container.getBoundingClientRect()
+      expect(elRect.left).to.be.greaterThan(containerRect.right)
+      expect(elRect.top).to.be.greaterThan(containerRect.bottom)
+    })
 
     // Cypress knows to scroll to the right and down
     cy.get('#scroll-both button').scrollIntoView()

--- a/test-project/cypress/e2e/2-advanced-examples/cookies.cy.js
+++ b/test-project/cypress/e2e/2-advanced-examples/cookies.cy.js
@@ -44,22 +44,27 @@ context('Cookies', () => {
     cy.setCookie('key', 'value')
     cy.setCookie('key', 'value', { domain: '.example.com' })
 
-    // cy.getAllCookies() yields an array of cookies
+    // cy.getAllCookies() yields an array of cookies (order is not guaranteed)
     cy.getAllCookies().should('have.length', 2).should((cookies) => {
-      // each cookie has these properties
-      expect(cookies[0]).to.have.property('name', 'key')
-      expect(cookies[0]).to.have.property('value', 'value')
-      expect(cookies[0]).to.have.property('httpOnly', false)
-      expect(cookies[0]).to.have.property('secure', false)
-      expect(cookies[0]).to.have.property('domain')
-      expect(cookies[0]).to.have.property('path')
+      const hostCookie = cookies.find((cookie) => cookie.domain !== '.example.com')
+      const exampleCookie = cookies.find((cookie) => cookie.domain === '.example.com')
 
-      expect(cookies[1]).to.have.property('name', 'key')
-      expect(cookies[1]).to.have.property('value', 'value')
-      expect(cookies[1]).to.have.property('httpOnly', false)
-      expect(cookies[1]).to.have.property('secure', false)
-      expect(cookies[1]).to.have.property('domain', '.example.com')
-      expect(cookies[1]).to.have.property('path')
+      // each cookie has these properties
+      expect(hostCookie).to.exist
+      expect(hostCookie).to.have.property('name', 'key')
+      expect(hostCookie).to.have.property('value', 'value')
+      expect(hostCookie).to.have.property('httpOnly', false)
+      expect(hostCookie).to.have.property('secure', false)
+      expect(hostCookie).to.have.property('domain')
+      expect(hostCookie).to.have.property('path')
+
+      expect(exampleCookie).to.exist
+      expect(exampleCookie).to.have.property('name', 'key')
+      expect(exampleCookie).to.have.property('value', 'value')
+      expect(exampleCookie).to.have.property('httpOnly', false)
+      expect(exampleCookie).to.have.property('secure', false)
+      expect(exampleCookie).to.have.property('domain', '.example.com')
+      expect(exampleCookie).to.have.property('path')
     })
   })
 

--- a/test-project/cypress/e2e/2-advanced-examples/cypress_api.cy.js
+++ b/test-project/cypress/e2e/2-advanced-examples/cypress_api.cy.js
@@ -109,32 +109,32 @@ context('Cypress APIs', () => {
     })
   })
 
-  context('Cypress.env()', () => {
+  context('Cypress.expose()', () => {
     beforeEach(() => {
       cy.visit('https://example.cypress.io/cypress-api')
     })
 
-    // We can set environment variables for highly dynamic values
+    // We can publicly expose values
 
     // https://on.cypress.io/environment-variables
     it('Get environment variables', () => {
     // https://on.cypress.io/env
     // set multiple environment variables
-      Cypress.env({
+      Cypress.expose({
         host: 'veronica.dev.local',
         api_server: 'http://localhost:8888/v1/',
       })
 
       // get environment variable
-      expect(Cypress.env('host')).to.eq('veronica.dev.local')
+      expect(Cypress.expose('host')).to.eq('veronica.dev.local')
 
       // set environment variable
-      Cypress.env('api_server', 'http://localhost:8888/v2/')
-      expect(Cypress.env('api_server')).to.eq('http://localhost:8888/v2/')
+      Cypress.expose('api_server', 'http://localhost:8888/v2/')
+      expect(Cypress.expose('api_server')).to.eq('http://localhost:8888/v2/')
 
       // get all environment variable
-      expect(Cypress.env()).to.have.property('host', 'veronica.dev.local')
-      expect(Cypress.env()).to.have.property('api_server', 'http://localhost:8888/v2/')
+      expect(Cypress.expose()).to.have.property('host', 'veronica.dev.local')
+      expect(Cypress.expose()).to.have.property('api_server', 'http://localhost:8888/v2/')
     })
   })
 

--- a/test-project/cypress/e2e/2-advanced-examples/misc.cy.js
+++ b/test-project/cypress/e2e/2-advanced-examples/misc.cy.js
@@ -18,8 +18,8 @@ context('Misc', () => {
 
     // on CircleCI Windows build machines we have a failure to run bash shell
     // https://github.com/cypress-io/cypress/issues/5169
-    // so skip some of the tests by passing flag "--env circle=true"
-    const isCircleOnWindows = Cypress.platform === 'win32' && Cypress.env('circle')
+    // so skip some of the tests by passing flag "--expose circle=true"
+    const isCircleOnWindows = Cypress.platform === 'win32' && Cypress.expose('circle')
 
     if (isCircleOnWindows) {
       cy.log('Skipping test on CircleCI')
@@ -29,7 +29,7 @@ context('Misc', () => {
 
     // cy.exec problem on Shippable CI
     // https://github.com/cypress-io/cypress/issues/6718
-    const isShippable = Cypress.platform === 'linux' && Cypress.env('shippable')
+    const isShippable = Cypress.platform === 'linux' && Cypress.expose('shippable')
 
     if (isShippable) {
       cy.log('Skipping test on ShippableCI')

--- a/test-project/package.json
+++ b/test-project/package.json
@@ -5,5 +5,8 @@
   "scripts": {
     "lint": "eslint",
     "test": "cypress run"
+  },
+  "allowScripts": {
+    "cypress": true
   }
 }


### PR DESCRIPTION
## Situation

The [test-project/README.md](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/test-project/README.md) contains instructions for maintainers who need to update the [test-project](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/test-project/README.md).

These instructions produce warnings when used with Node.js 24.18.0, as specified in [.node-version](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/.node-version), with bundled npm@11.16.0:

```console
npm warn allow-scripts 1 package has install scripts not yet covered by allowScripts:
npm warn allow-scripts   cypress@15.18.1 (postinstall: node dist/index.js --exec install)
npm warn allow-scripts
npm warn allow-scripts Run `npm approve-scripts --allow-scripts-pending` to review, or `npm approve-scripts <pkg>` to allow.
```

Additionally, if the dependencies from the root of the repo, which now includes `typescript`, are installed, then running the instructions will attempt to scaffold a TypeScript project, instead of a JavaScript project. Cypress does not give a choice about this. See https://github.com/cypress-io/cypress/issues/27621.

## Change

Update the [test-project/README.md](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/test-project/README.md)  documentation:

- Clear out any previously installed dependencies
- Add npm `allowScripts` for `cypress`
- Jump directly into the E2E setup with Electron to reduce the number of other manual steps

```shell
git clean -xfd
npm install cypress@latest --no-package-lock
npx cypress install --e2e --browser electron
```

Commit the updated scaffolded tests, installed with `cypress@15.18.1`.

## Verification

On Ubuntu 24.04.4 LTS, Node.js 24.18.0

Follow the instructions in [test-project/README.md](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/test-project/README.md) and confirm success without warnings.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the eslint-plugin’s test fixture and documentation; no production runtime or security-sensitive paths are affected.
> 
> **Overview**
> Refreshes the **test-project** fixture to match Cypress **15.18.1** scaffold output and updates maintainer docs so rescaffolding works cleanly on **Node 24 / npm 11** (no `allow-scripts` warnings, no accidental TypeScript scaffold from repo root deps).
> 
> **Docs / workflow:** Adds `git clean -xfd`, documents `allowScripts` for Cypress, opens Cypress with `--e2e --browser electron`, and points local lint at `eslint-configs/eslint.recommended.mjs`.
> 
> **Committed scaffold:** `cypress.config.js` sets `allowCypressEnv: false`; `package.json` adds `allowScripts.cypress`. Example specs drop `Cypress.env` in favor of **`Cypress.expose`**, harden cookie assertions for non-deterministic order, and replace off-screen visibility checks with **bounding-rect** assertions before `scrollIntoView`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 436630779dd6cc32f900df34d6b45ba25aa78945. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->