### PR TITLE
chore: set endOfLine to lf

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# See https://editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
## Situation

- As described in https://github.com/cypress-io/eslint-plugin-cypress/issues/265 [eslint-doc-generator](https://github.com/bmish/eslint-doc-generator) can produce incorrect results when run on Windows after Prettier has been run.

## Change

Follow advice in Prettier [End of Line](https://prettier.io/docs/options#end-of-line) documentation.

1. Create [.gitattributes](https://git-scm.com/docs/gitattributes) with

    ```text
    * text=auto eol=lf
    ```

2. Create [.editorconfig](https://editorconfig.org/) with the following:

    ```text
    # See https://editorconfig.org
    root = true
    [*]
    end_of_line = lf
    insert_final_newline = true
    ```

This affects only the use of the repo on Windows. It changes the end-of-line character from CR/LF to LF, consistent with Linux which already uses LF as end-of-line character.



## Verification

After merge of https://github.com/cypress-io/eslint-plugin-cypress/pull/381, re-test with `eslint-doc-generator` on Linux and Windows.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Repo hygiene only; no runtime, auth, or application logic changes—main effect is normalized line endings on Windows clones.
> 
> **Overview**
> Standardizes **LF** line endings across the repo so Windows checkouts match Linux and tools like Prettier and `eslint-doc-generator` don’t fight over CRLF vs LF.
> 
> Adds **`.gitattributes`** (`* text=auto eol=lf`) so Git normalizes text files to LF on checkout/commit, and **`.editorconfig`** (`end_of_line = lf`, `insert_final_newline = true`) so editors align with that policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15bfc2b055a5e1070f19b7cd3442e0b094898655. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->