### PR TITLE
test: add vitest slowTestThreshold 600 ms

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     include: ['**/tests/**/*.[jt]s?(x)'],
+    slowTestThreshold: 600,
     globals: true
   },
 })


### PR DESCRIPTION
- closes https://github.com/cypress-io/eslint-plugin-cypress/issues/384

## Situation

When running tests, the output from `npm test`, or individually from:

```shell
npx vitest run tests/lib/rules/unsafe-to-chain-command.js
```

may contain additional log lines:

```console
       ✓ cy.get("new-todo").type("todo A{enter}"); cy.get("new-todo").type("todo B{enter}"); cy.get("new-todo").should("have.class", "active");  362ms
       ✓
        /// <reference types="cypress" />
        function getTodo() {
          return cy.get("new-todo");
        }
        getTodo().type("todo A{enter}");
        getTodo().type("todo B{enter}");
        336ms
```

These are also seen in CircleCI logs, such as https://app.circleci.com/pipelines/github/cypress-io/eslint-plugin-cypress/798/workflows/ad5ba0d3-7b68-4490-b932-5ee953276233/jobs/5250

## Change

Add [slowTestThreshold](https://vitest.dev/config/slowtestthreshold) 600 (ms) to [vitest.config.mts](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/vitest.config.mts). This is twice the default value of 300 (ms).

## Verification

Ubuntu 24.04.4 LTS, Node.js 24.18.0 LTS

```shell
git clone https://github.com/cypress-io/eslint-plugin-cypress
cd eslint-plugin-cypress
npm ci
npx vitest run tests/lib/rules/unsafe-to-chain-command.js
```

and confirm that only the summary, similar to the following, is shown:

```console
 ✓ tests/lib/rules/unsafe-to-chain-command.js (18 tests) 1040ms
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-runner configuration only; no production or lint-rule behavior changes.
> 
> **Overview**
> Raises Vitest’s **`slowTestThreshold`** from the default **300ms** to **600ms** in `vitest.config.mts`.
> 
> This stops Vitest from printing extra “slow test” detail lines for rule tests that often run **~300–360ms**, so `npm test` and CI logs show a compact per-file summary instead of per-test timing noise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ee01ab76c4298db915e9782e76fd205fe3effd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->