### PR TITLE
fix: Potential null reference in `isIdentifierNumberConstArgument`

### DIFF
--- a/lib/rules/no-unnecessary-waiting.js
+++ b/lib/rules/no-unnecessary-waiting.js
@@ -62,7 +62,11 @@ function isIdentifierNumberConstArgument(node, scope) {
   if (node.arguments[0].type !== 'Identifier') return false
 
   const identifier = node.arguments[0]
-  const resolvedIdentifier = scope.references.find((ref) => ref.identifier === identifier).resolved
+  const ref = scope.references.find((ref) => ref.identifier === identifier)
+
+  if (!ref || !ref.resolved) return false
+
+  const resolvedIdentifier = ref.resolved
   const definition = resolvedIdentifier.defs[0]
   const isVariable = definition.type === 'Variable'
 

--- a/lib/rules/no-unnecessary-waiting.js
+++ b/lib/rules/no-unnecessary-waiting.js
@@ -64,7 +64,7 @@ function isIdentifierNumberConstArgument(node, scope) {
   const identifier = node.arguments[0]
   const ref = scope.references.find((ref) => ref.identifier === identifier)
 
-  if (!ref || !ref.resolved) return false
+  if (!ref || !ref.resolved || ref.resolved.defs.length === 0) return false
 
   const resolvedIdentifier = ref.resolved
   const definition = resolvedIdentifier.defs[0]


### PR DESCRIPTION
## Summary

Potential null reference in `isIdentifierNumberConstArgument`

## Problem

**File**: `lib/rules/no-unnecessary-waiting.js:L80`

In `lib/rules/no-unnecessary-waiting.js`, the `isIdentifierNumberConstArgument` function calls `.find()` on `scope.references` and immediately accesses `.resolved` on the result. If the identifier is not found in the scope references (e.g., global variables, unresolved references), `.find()` returns `undefined`, causing a `TypeError` when attempting to access `.resolved`. This can crash the ESLint process when linting code that uses such variables with `cy.wait()`.

## Solution

Add a null check for the result of `.find()` before accessing `.resolved`. For example: `const ref = scope.references.find((ref) => ref.identifier === identifier); if (!ref || !ref.resolved) return false; const resolvedIdentifier = ref.resolved;`

## Changes

- `lib/rules/no-unnecessary-waiting.js` (modified)