### PR TITLE
fix: remove 'each' from unsafe-to-chain-command list

### DIFF
--- a/lib/rules/unsafe-to-chain-command.js
+++ b/lib/rules/unsafe-to-chain-command.js
@@ -19,7 +19,6 @@ const unsafeToChainActions = [
   'click',
   'check',
   'dblclick',
-  'each',
   'focus',
   'rightclick',
   'screenshot',

--- a/tests/lib/rules/unsafe-to-chain-command.js
+++ b/tests/lib/rules/unsafe-to-chain-command.js
@@ -10,13 +10,13 @@ const errors = [{ messageId: 'unexpected' }]
 
 const tests = {
   valid: [
-    {
-      code: 'cy.get("new-todo").type("todo A{enter}"); cy.get("new-todo").type("todo B{enter}"); cy.get("new-todo").should("have.class", "active");',
-    },
-    { code: 'cy.focused().should("be.visible");' },
-    { code: 'cy.submitBtn().click();' },
-  ],
-
+  {
+    code: 'cy.get("new-todo").type("todo A{enter}"); cy.get("new-todo").type("todo B{enter}"); cy.get("new-todo").should("have.class", "active");',
+  },
+  { code: 'cy.focused().should("be.visible");' },
+  { code: 'cy.submitBtn().click();' },
+  { code: 'cy.get("li").each(($li, index, $lis) => { return "something else" }).then(($lis) => { expect($lis).to.have.length(3) });' },
+],
   invalid: [
     { code: 'cy.get("new-todo").type("todo A{enter}").should("have.class", "active");', errors },
     { code: 'cy.get("new-todo").type("todo A{enter}").type("todo B{enter}");', errors },


### PR DESCRIPTION

## What this fixes

The `unsafe-to-chain-command` rule incorrectly listed `.each()` as an
unsafe command to chain from, causing false positive lint errors on
valid Cypress code such as:

```js
cy.get('li')
  .should('have.length', 3)
  .each(($li, index, $lis) => {
    return 'something else'
  })
  .then(($lis) => {
    expect($lis).to.have.length(3) // true
  })
```

Unlike commands such as `.click()` or `.type()`, `.each()` correctly
passes its original subject forward to the next command in the chain.
It does not carry the "unsafe to chain" warning in Cypress's own
documentation, so it shouldn't be in this rule's unsafe-actions list.

## Changes

- Removed `'each'` from the `unsafeToChainActions` list in
  `lib/rules/unsafe-to-chain-command.js`
- Added a test case confirming `.each()` followed by `.then()` no
  longer triggers a false positive

Fixes #246