### PR TITLE
chore(ci): run eslint-doc-generator check in ci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -58,6 +58,10 @@ jobs:
           name: Lint code with Prettier
           command: npm run format:check
 
+      - run:
+          name: Lint code with eslint-doc-generator
+          command: npx eslint-doc-generator --check
+
   test-v9:
     executor: docker-executor
     steps:


### PR DESCRIPTION
## Situation

The `lint` job of [circle.yml](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/circle.yml) does not lint against [eslint-doc-generator](https://github.com/eslint-community/eslint-doc-generator) results, so it is possible for PRs to pass linting that have not followed the [CONTRIBUTING.md](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/CONTRIBUTING.md) instructions to use the doc generator.

## Change

Add an [eslint-doc-generator --check](https://github.com/eslint-community/eslint-doc-generator) step to the [circle.yml](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/circle.yml) `lint` job.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only guardrail with no application, auth, or data-path changes.
> 
> **Overview**
> The CircleCI **`lint`** job now runs **`npx eslint-doc-generator --check`** after ESLint and Prettier, so PRs fail if rule documentation is out of date with what contributors are expected to generate per **CONTRIBUTING.md**.
> 
> This closes the gap where local lint could pass without regenerated docs; it does not change plugin runtime behavior or release steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4553a1be5a4d22d23e5dba2109d9cc27786b295a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->